### PR TITLE
Alternative view for widgets with no data

### DIFF
--- a/__mocks__/allergy.mock.ts
+++ b/__mocks__/allergy.mock.ts
@@ -1558,3 +1558,96 @@ export const mockAllergyResult = {
     }
   }
 };
+
+export const mockPatientAllergiesResult = {
+  data: {
+    total: 2,
+    entry: [
+      {
+        resource: {
+          resourceType: "AllergyIntolerance",
+          id: "67a8dad8-0d35-4afd-a838-f96913614c53",
+          category: ["medication"],
+          criticality: "?",
+          code: {
+            coding: [
+              {
+                system: "http://openmrs.org",
+                code: "162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                display: "ACE inhibitors"
+              }
+            ],
+            text: "ACE inhibitors"
+          },
+          note: [
+            {
+              text: "comment"
+            }
+          ],
+          reaction: [
+            {
+              manifestation: [
+                {
+                  coding: [
+                    {
+                      system: "http://openmrs.org",
+                      code: "124AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                      display: "AMOEBIASIS"
+                    }
+                  ],
+                  text: "AMOEBIASIS"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        resource: {
+          resourceType: "AllergyIntolerance",
+          id: "b6c8efa1-e823-46ac-ae09-83b2b0b96a48",
+          extension: [
+            {
+              url:
+                "http://fhir-es.transcendinsights.com/stu3/StructureDefinition/resource-date-created",
+              valueDateTime: "2019-06-21T13:43:47+00:00"
+            },
+            {
+              url:
+                "https://purl.org/elab/fhir/StructureDefinition/Creator-crew-version1",
+              valueString: "user2"
+            }
+          ],
+          category: ["medication"],
+          criticality: "low",
+          code: {
+            coding: [
+              {
+                system: "http://openmrs.org",
+                code: "162299AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                display: "ARBs (angiotensin II receptor blockers)"
+              }
+            ],
+            text: "ARBs (angiotensin II receptor blockers)"
+          },
+          reaction: [
+            {
+              manifestation: [
+                {
+                  coding: [
+                    {
+                      system: "http://openmrs.org",
+                      code: "124AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                      display: "AMOEBIASIS"
+                    }
+                  ],
+                  text: "AMOEBIASIS"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+};

--- a/__mocks__/height-and-weight.mock.ts
+++ b/__mocks__/height-and-weight.mock.ts
@@ -1,0 +1,299 @@
+export const mockHeightAndWeightResponse = [
+  {
+    id: 1578900900000,
+    weight: 85,
+    height: 185,
+    date: "13-Jan 10:35 AM",
+    bmi: "24.8",
+    obsData: {
+      weight: {
+        uuid: "deb6a5a3-9e10-4359-833c-13a6e84e0604",
+        display: "Weight (kg): 85.0",
+        obsDatetime: "2020-01-13T07:35:00.000+0000",
+        encounter: {
+          encounterDatetime: "2020-01-13T07:35:00.000+0000"
+        },
+        value: 85,
+        concept: {
+          uuid: "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      },
+      height: {
+        uuid: "50ebeb41-6744-40d3-a278-4d90b71ff90f",
+        display: "Height (cm): 185.0",
+        obsDatetime: "2020-01-13T07:35:00.000+0000",
+        encounter: {
+          encounterDatetime: "2020-01-13T07:35:00.000+0000"
+        },
+        value: 185,
+        concept: {
+          uuid: "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      }
+    }
+  },
+  {
+    id: 1578900600000,
+    weight: 85,
+    height: 185,
+    date: "13-Jan 10:30 AM",
+    bmi: "24.8",
+    obsData: {
+      weight: {
+        uuid: "88488a24-6fbb-4240-982f-948208a87d9b",
+        display: "Weight (kg): 85.0",
+        obsDatetime: "2020-01-13T07:30:00.000+0000",
+        encounter: {
+          encounterDatetime: "2020-01-13T07:35:00.000+0000"
+        },
+        value: 85,
+        concept: {
+          uuid: "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      },
+      height: {
+        uuid: "96944515-0a83-4855-bd2b-062a01f419bb",
+        display: "Height (cm): 185.0",
+        obsDatetime: "2020-01-13T07:30:00.000+0000",
+        encounter: {
+          encounterDatetime: "2020-01-13T07:35:00.000+0000"
+        },
+        value: 185,
+        concept: {
+          uuid: "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      }
+    }
+  },
+  {
+    id: 1578900000000,
+    weight: 85,
+    height: 185,
+    date: "13-Jan 10:20 AM",
+    bmi: "24.8",
+    obsData: {
+      weight: {
+        uuid: "490ec124-3954-420d-bd08-c05aaf2a5bac",
+        display: "Weight (kg): 85.0",
+        obsDatetime: "2020-01-13T07:20:00.000+0000",
+        encounter: {
+          encounterDatetime: "2020-01-13T07:35:00.000+0000"
+        },
+        value: 85,
+        concept: {
+          uuid: "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      },
+      height: {
+        uuid: "b8e987e7-6e74-44c1-b862-c607783c4b93",
+        display: "Height (cm): 185.0",
+        obsDatetime: "2020-01-13T07:20:00.000+0000",
+        encounter: {
+          encounterDatetime: "2020-01-13T07:35:00.000+0000"
+        },
+        value: 185,
+        concept: {
+          uuid: "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      }
+    }
+  },
+  {
+    id: 1578899952000,
+    weight: 85,
+    height: 185,
+    date: "13-Jan 10:19 AM",
+    bmi: "24.8",
+    obsData: {
+      weight: {
+        uuid: "a73579d8-e80f-479a-96ac-186e15657ccd",
+        display: "Weight (kg): 85.0",
+        obsDatetime: "2020-01-13T07:19:12.000+0000",
+        encounter: {
+          encounterDatetime: "2020-01-13T07:35:00.000+0000"
+        },
+        value: 85,
+        concept: {
+          uuid: "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      },
+      height: {
+        uuid: "5b423d8d-0600-4ee3-ac54-0504eafe532f",
+        display: "Height (cm): 185.0",
+        obsDatetime: "2020-01-13T07:19:12.000+0000",
+        encounter: {
+          encounterDatetime: "2020-01-13T07:35:00.000+0000"
+        },
+        value: 185,
+        concept: {
+          uuid: "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      }
+    }
+  },
+  {
+    id: 1578874440000,
+    weight: 25,
+    height: 25,
+    date: "13-Jan 03:14 AM",
+    bmi: "400.0",
+    obsData: {
+      weight: {
+        uuid: "91da1a7e-3a50-410a-9433-7727d763d8fe",
+        display: "Weight (kg): 25.0",
+        obsDatetime: "2020-01-13T00:14:00.000+0000",
+        encounter: {
+          encounterDatetime: "2020-01-13T00:14:00.000+0000"
+        },
+        value: 25,
+        concept: {
+          uuid: "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      },
+      height: {
+        uuid: "5869855d-c6b1-49cd-861d-3ef373cc21d3",
+        display: "Height (cm): 25.0",
+        obsDatetime: "2020-01-13T00:14:00.000+0000",
+        encounter: {
+          encounterDatetime: "2020-01-13T00:14:00.000+0000"
+        },
+        value: 25,
+        concept: {
+          uuid: "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      }
+    }
+  },
+  {
+    id: 1578661675000,
+    weight: 90,
+    height: 190,
+    date: "10-Jan 04:07 PM",
+    bmi: "24.9",
+    obsData: {
+      weight: {
+        uuid: "2b9c4586-1570-4ddc-b2e4-655ed57e4be1",
+        display: "Weight (kg): 90.0",
+        obsDatetime: "2020-01-10T13:07:55.000+0000",
+        encounter: {
+          encounterDatetime: "2020-01-10T13:07:55.000+0000"
+        },
+        value: 90,
+        concept: {
+          uuid: "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      },
+      height: {
+        uuid: "32be8f1c-3a54-4e51-9650-b22880a4da22",
+        display: "Height (cm): 190.0",
+        obsDatetime: "2020-01-10T13:07:55.000+0000",
+        encounter: {
+          encounterDatetime: "2020-01-10T13:07:55.000+0000"
+        },
+        value: 190,
+        concept: {
+          uuid: "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      }
+    }
+  },
+  {
+    id: 1547381580000,
+    weight: 65,
+    height: 185,
+    date: "2019 13-Jan",
+    bmi: "19.0",
+    obsData: {
+      weight: {
+        uuid: "97af6f36-be7f-4972-943b-475fdb82f52b",
+        display: "Weight (kg): 65.0",
+        obsDatetime: "2019-01-13T12:13:00.000+0000",
+        encounter: {
+          encounterDatetime: "2019-01-13T12:13:00.000+0000"
+        },
+        value: 65,
+        concept: {
+          uuid: "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      },
+      height: {
+        uuid: "9add6abb-f458-4e5d-9f86-2a86505d6fe7",
+        display: "Height (cm): 185.0",
+        obsDatetime: "2019-01-13T12:13:00.000+0000",
+        encounter: {
+          encounterDatetime: "2019-01-13T12:13:00.000+0000"
+        },
+        value: 185,
+        concept: {
+          uuid: "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      }
+    }
+  },
+  {
+    id: 1463379216000,
+    weight: 242,
+    height: 84,
+    date: "2016 16-May",
+    bmi: "343.0",
+    obsData: {
+      weight: {
+        uuid: "5cfbedaa-b981-406b-bb43-03e312a0f0d3",
+        display: "Weight (kg): 242.0",
+        obsDatetime: "2016-05-16T06:13:36.000+0000",
+        encounter: {
+          encounterDatetime: "2016-05-16T06:05:00.000+0000"
+        },
+        value: 242,
+        concept: {
+          uuid: "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      },
+      height: {
+        uuid: "690afa06-9779-42ca-af33-d62548488bc9",
+        display: "Height (cm): 84.0",
+        obsDatetime: "2016-05-16T06:13:36.000+0000",
+        encounter: {
+          encounterDatetime: "2016-05-16T06:05:00.000+0000"
+        },
+        value: 84,
+        concept: {
+          uuid: "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      }
+    }
+  },
+  {
+    id: 1463378700000,
+    weight: 242,
+    height: 84,
+    date: "2016 16-May",
+    bmi: "343.0",
+    obsData: {
+      weight: {
+        uuid: "b4f7284a-2575-47d6-a889-ac5d3d596184",
+        display: "Weight (kg): 242.0",
+        obsDatetime: "2016-05-16T06:05:00.000+0000",
+        encounter: {
+          encounterDatetime: "2016-05-16T06:05:00.000+0000"
+        },
+        value: 242,
+        concept: {
+          uuid: "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      },
+      height: {
+        uuid: "e28e7c6a-bede-4571-ba61-21b058aa8b09",
+        display: "Height (cm): 84.0",
+        obsDatetime: "2016-05-16T06:05:00.000+0000",
+        encounter: {
+          encounterDatetime: "2016-05-16T06:05:00.000+0000"
+        },
+        value: 84,
+        concept: {
+          uuid: "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      }
+    }
+  }
+];

--- a/src/widgets/allergies/allergies-overview.component.tsx
+++ b/src/widgets/allergies/allergies-overview.component.tsx
@@ -1,15 +1,15 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import SummaryCardRow from "../../ui-components/cards/summary-card-row.component";
 import { performPatientAllergySearch } from "./allergy-intolerance.resource";
-import style from "./allergies-overview.css";
+import styles from "./allergies-overview.css";
 import HorizontalLabelValue from "../../ui-components/cards/horizontal-label-value.component";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import { useRouteMatch } from "react-router-dom";
 
 export default function AllergyOverview(props: AllergyOverviewProps) {
-  const [patientAllergy, setPatientAllergy] = React.useState(null);
+  const [patientAllergies, setPatientAllergies] = useState(null);
   const [
     isLoadingPatient,
     patient,
@@ -22,50 +22,66 @@ export default function AllergyOverview(props: AllergyOverviewProps) {
     match.url.substr(0, match.url.search("/chart/")) + "/chart";
   const allergiesPath = chartBasePath + "/" + props.basePath;
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (patient) {
       const abortController = new AbortController();
 
       performPatientAllergySearch(patient.identifier[0].value, abortController)
-        .then(allergy => setPatientAllergy(allergy.data))
+        .then(allergy => setPatientAllergies(allergy.data))
         .catch(createErrorHandler());
 
       return () => abortController.abort();
     }
   }, [patient]);
 
+  function displayAllergies() {
+    return (
+      <SummaryCard
+        name="Allergies"
+        styles={{ margin: "1.25rem, 1.5rem" }}
+        link={`/patient/${patientUuid}/chart/allergies`}
+      >
+        {patientAllergies &&
+          patientAllergies.total > 0 &&
+          patientAllergies.entry.map(allergy => {
+            return (
+              <SummaryCardRow
+                key={allergy.resource.id}
+                linkTo={`${allergiesPath}/${allergy.resource.id}`}
+              >
+                <HorizontalLabelValue
+                  label={allergy.resource.code.text}
+                  labelClassName="omrs-bold"
+                  labelStyles={{ flex: "1" }}
+                  value={`${
+                    allergy.resource.reaction[0].manifestation[0].text
+                  } (${
+                    allergy.resource.criticality === "?"
+                      ? "\u2014"
+                      : allergy.resource.criticality
+                  })`}
+                  valueStyles={{ flex: "1", paddingLeft: "1rem" }}
+                  valueClassName={styles.allergyReaction}
+                />
+              </SummaryCardRow>
+            );
+          })}
+      </SummaryCard>
+    );
+  }
+
   return (
-    <SummaryCard
-      name="Allergies"
-      styles={{ margin: "1.25rem, 1.5rem" }}
-      link={`/patient/${patientUuid}/chart/allergies`}
-    >
-      {patientAllergy &&
-        patientAllergy.total > 0 &&
-        patientAllergy.entry.map(allergy => {
-          return (
-            <SummaryCardRow
-              key={allergy.resource.id}
-              linkTo={`${allergiesPath}/${allergy.resource.id}`}
-            >
-              <HorizontalLabelValue
-                label={allergy.resource.code.text}
-                labelClassName="omrs-bold"
-                labelStyles={{ flex: "1" }}
-                value={`${
-                  allergy.resource.reaction[0].manifestation[0].text
-                } (${
-                  allergy.resource.criticality === "?"
-                    ? "\u2014"
-                    : allergy.resource.criticality
-                })`}
-                valueStyles={{ flex: "1", paddingLeft: "1rem" }}
-                valueClassName={style.allergyReaction}
-              />
-            </SummaryCardRow>
-          );
-        })}
-    </SummaryCard>
+    <>
+      {patientAllergies && patientAllergies.total > 0 ? (
+        displayAllergies()
+      ) : (
+        <SummaryCard name="Allergies">
+          <div className={styles.emptyAllergies}>
+            <p className="omrs-type-body-regular">No Allergies recorded.</p>
+          </div>
+        </SummaryCard>
+      )}
+    </>
   );
 }
 

--- a/src/widgets/allergies/allergies-overview.css
+++ b/src/widgets/allergies/allergies-overview.css
@@ -6,3 +6,9 @@
 .allergyReaction::first-letter {
   text-transform: capitalize;
 }
+
+.emptyAllergies p {
+  text-align: left;
+  padding-left: 1rem;
+  font-weight: 500;
+}

--- a/src/widgets/allergies/allergies-overview.test.tsx
+++ b/src/widgets/allergies/allergies-overview.test.tsx
@@ -3,8 +3,11 @@ import { render, cleanup, wait } from "@testing-library/react";
 import AllergyOverview from "./allergies-overview.component";
 import { BrowserRouter } from "react-router-dom";
 import { performPatientAllergySearch } from "./allergy-intolerance.resource";
-import { act } from "react-dom/test-utils";
 import { useCurrentPatient } from "@openmrs/esm-api";
+import {
+  patient,
+  mockPatientAllergiesResult
+} from "../../../__mocks__/allergy.mock";
 
 const mockPerformPatientAllergySearch = performPatientAllergySearch as jest.Mock;
 const mockUseCurrentPatient = useCurrentPatient as jest.Mock;
@@ -21,147 +24,6 @@ jest.mock("@openmrs/esm-api", () => ({
   useCurrentPatient: jest.fn()
 }));
 
-const mockPatientAllergyResult = {
-  data: {
-    total: 2,
-    entry: [
-      {
-        resource: {
-          resourceType: "AllergyIntolerance",
-          id: "67a8dad8-0d35-4afd-a838-f96913614c53",
-          category: ["medication"],
-          criticality: "?",
-          code: {
-            coding: [
-              {
-                system: "http://openmrs.org",
-                code: "162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                display: "ACE inhibitors"
-              }
-            ],
-            text: "ACE inhibitors"
-          },
-          note: [
-            {
-              text: "comment"
-            }
-          ],
-          reaction: [
-            {
-              manifestation: [
-                {
-                  coding: [
-                    {
-                      system: "http://openmrs.org",
-                      code: "124AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      display: "AMOEBIASIS"
-                    }
-                  ],
-                  text: "AMOEBIASIS"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        resource: {
-          resourceType: "AllergyIntolerance",
-          id: "b6c8efa1-e823-46ac-ae09-83b2b0b96a48",
-          extension: [
-            {
-              url:
-                "http://fhir-es.transcendinsights.com/stu3/StructureDefinition/resource-date-created",
-              valueDateTime: "2019-06-21T13:43:47+00:00"
-            },
-            {
-              url:
-                "https://purl.org/elab/fhir/StructureDefinition/Creator-crew-version1",
-              valueString: "user2"
-            }
-          ],
-          category: ["medication"],
-          criticality: "low",
-          code: {
-            coding: [
-              {
-                system: "http://openmrs.org",
-                code: "162299AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                display: "ARBs (angiotensin II receptor blockers)"
-              }
-            ],
-            text: "ARBs (angiotensin II receptor blockers)"
-          },
-          reaction: [
-            {
-              manifestation: [
-                {
-                  coding: [
-                    {
-                      system: "http://openmrs.org",
-                      code: "124AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      display: "AMOEBIASIS"
-                    }
-                  ],
-                  text: "AMOEBIASIS"
-                }
-              ]
-            }
-          ]
-        }
-      }
-    ]
-  }
-};
-
-const patient: fhir.Patient = {
-  resourceType: "Patient",
-  id: "8673ee4f-e2ab-4077-ba55-4980f408773e",
-  extension: [
-    {
-      url:
-        "http://fhir-es.transcendinsights.com/stu3/StructureDefinition/resource-date-created",
-      valueDateTime: "2017-01-18T09:42:40+00:00"
-    },
-    {
-      url:
-        "https://purl.org/elab/fhir/StructureDefinition/Creator-crew-version1",
-      valueString: "daemon"
-    }
-  ],
-  identifier: [
-    {
-      id: "1f0ad7a1-430f-4397-b571-59ea654a52db",
-      use: "usual",
-      system: "OpenMRS ID",
-      value: "10010W"
-    }
-  ],
-  active: true,
-  name: [
-    {
-      id: "efdb246f-4142-4c12-a27a-9be60b9592e9",
-      use: "usual",
-      family: "Wilson",
-      given: ["John"]
-    }
-  ],
-  gender: "male",
-  birthDate: "1972-04-04",
-  deceasedBoolean: false,
-  address: [
-    {
-      id: "0c244eae-85c8-4cc9-b168-96b51f864e77",
-      use: "home",
-      line: ["Address10351"],
-      city: "City0351",
-      state: "State0351tested",
-      postalCode: "60351",
-      country: "Country0351"
-    }
-  ]
-};
-
 describe("<AllergyOverview/>", () => {
   let match, wrapper: any;
 
@@ -170,14 +32,15 @@ describe("<AllergyOverview/>", () => {
   beforeEach(() => {
     match = { params: {}, isExact: false, path: "/", url: "/" };
   });
-
   beforeEach(mockPerformPatientAllergySearch.mockReset);
   beforeEach(mockUseCurrentPatient.mockReset);
+  beforeEach(() => {
+    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
+  });
 
   it("render AllergyOverview without dying", async () => {
-    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
     mockPerformPatientAllergySearch.mockReturnValue(
-      Promise.resolve(mockPatientAllergyResult)
+      Promise.resolve(mockPatientAllergiesResult)
     );
     wrapper = render(
       <BrowserRouter>
@@ -191,9 +54,8 @@ describe("<AllergyOverview/>", () => {
   });
 
   it("should display the patient allergy reaction and manifestation", async () => {
-    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
     mockPerformPatientAllergySearch.mockReturnValue(
-      Promise.resolve(mockPatientAllergyResult)
+      Promise.resolve(mockPatientAllergiesResult)
     );
     wrapper = render(
       <BrowserRouter>
@@ -201,8 +63,27 @@ describe("<AllergyOverview/>", () => {
       </BrowserRouter>
     );
     await wait(() => {
+      expect(wrapper).toBeDefined();
       expect(wrapper.getByText("ACE inhibitors")).toBeTruthy();
       expect(wrapper.getByText("AMOEBIASIS (—)")).toBeTruthy();
+    });
+  });
+
+  it("should not display the patient's allergies when there are no allergies", async () => {
+    mockPerformPatientAllergySearch.mockReturnValue(
+      Promise.resolve({ data: { total: 0 } })
+    );
+    wrapper = render(
+      <BrowserRouter>
+        <AllergyOverview />
+      </BrowserRouter>
+    );
+
+    await wait(() => {
+      expect(wrapper).toBeDefined();
+      expect(
+        wrapper.getByText("No Allergies recorded.").textContent
+      ).toBeDefined();
     });
   });
 });

--- a/src/widgets/appointments/appointments-overview.component.tsx
+++ b/src/widgets/appointments/appointments-overview.component.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { getAppointments } from "./appointments.resource";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import dayjs from "dayjs";
@@ -10,7 +10,7 @@ import AppointmentsForm from "./appointments-form.component";
 import { useRouteMatch, Link } from "react-router-dom";
 
 export default function AppointmentsOverview(props: AppointmentOverviewProps) {
-  const [patientAppointments, setPatientAppointments] = React.useState([]);
+  const [patientAppointments, setPatientAppointments] = useState([]);
   const [
     isLoadingPatient,
     patient,
@@ -19,7 +19,7 @@ export default function AppointmentsOverview(props: AppointmentOverviewProps) {
   ] = useCurrentPatient();
   const startDate = dayjs().format();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const abortController = new AbortController();
     if (patientUuid) {
       getAppointments(patientUuid, startDate, abortController).then(
@@ -77,7 +77,19 @@ export default function AppointmentsOverview(props: AppointmentOverviewProps) {
     );
   }
 
-  return restAPIAppointmentsOverview();
+  return (
+    <>
+      {patientAppointments && patientAppointments.length ? (
+        restAPIAppointmentsOverview()
+      ) : (
+        <SummaryCard name="Appointments">
+          <div className={styles.emptyAppointments}>
+            <p className="omrs-type-body-regular">No Appointments scheduled.</p>
+          </div>
+        </SummaryCard>
+      )}
+    </>
+  );
 }
 
 type AppointmentOverviewProps = {

--- a/src/widgets/appointments/appointments-overview.css
+++ b/src/widgets/appointments/appointments-overview.css
@@ -20,3 +20,9 @@
 .appointmentTable tbody tr td:nth-child(1) {
   font-family: "Work Sans";
 }
+
+.emptyAppointments p {
+  text-align: left;
+  padding-left: 1rem;
+  font-weight: 500;
+}

--- a/src/widgets/conditions/conditions-overview.component.tsx
+++ b/src/widgets/conditions/conditions-overview.component.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import styles from "./conditions-overview.css";
 import dayjs from "dayjs";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import SummaryCardRow from "../../ui-components/cards/summary-card-row.component";
@@ -39,48 +40,64 @@ export default function ConditionsOverview(props: ConditionsOverviewProps) {
     }
   }, [patient]);
 
+  function displayConditions() {
+    return (
+      <SummaryCard
+        name={t("conditions", "Conditions")}
+        styles={{ margin: "1.25rem, 1.5rem" }}
+        link={conditionsPath}
+      >
+        <SummaryCardRow>
+          <SummaryCardRowContent>
+            <HorizontalLabelValue
+              label="Active Conditions"
+              labelStyles={{
+                color: "var(--omrs-color-ink-medium-contrast)",
+                fontFamily: "Work Sans"
+              }}
+              value="Since"
+              valueStyles={{
+                color: "var(--omrs-color-ink-medium-contrast)",
+                fontFamily: "Work Sans"
+              }}
+            />
+          </SummaryCardRowContent>
+        </SummaryCardRow>
+        {patientConditions &&
+          patientConditions.entry.map(condition => {
+            return (
+              <SummaryCardRow
+                key={condition.resource.id}
+                linkTo={`${conditionsPath}/${condition.resource.id}`}
+              >
+                <HorizontalLabelValue
+                  label={condition.resource.code.text}
+                  labelStyles={{ fontWeight: 500 }}
+                  value={dayjs(condition.resource.onsetDateTime).format(
+                    "MMM-YYYY"
+                  )}
+                  valueStyles={{ fontFamily: "Work Sans" }}
+                />
+              </SummaryCardRow>
+            );
+          })}
+        <SummaryCardFooter linkTo={conditionsPath} />
+      </SummaryCard>
+    );
+  }
+
   return (
-    <SummaryCard
-      name={t("conditions", "Conditions")}
-      styles={{ margin: "1.25rem, 1.5rem" }}
-      link={conditionsPath}
-    >
-      <SummaryCardRow>
-        <SummaryCardRowContent>
-          <HorizontalLabelValue
-            label="Active Conditions"
-            labelStyles={{
-              color: "var(--omrs-color-ink-medium-contrast)",
-              fontFamily: "Work Sans"
-            }}
-            value="Since"
-            valueStyles={{
-              color: "var(--omrs-color-ink-medium-contrast)",
-              fontFamily: "Work Sans"
-            }}
-          />
-        </SummaryCardRowContent>
-      </SummaryCardRow>
-      {patientConditions &&
-        patientConditions.entry.map(condition => {
-          return (
-            <SummaryCardRow
-              key={condition.resource.id}
-              linkTo={`${conditionsPath}/${condition.resource.id}`}
-            >
-              <HorizontalLabelValue
-                label={condition.resource.code.text}
-                labelStyles={{ fontWeight: 500 }}
-                value={dayjs(condition.resource.onsetDateTime).format(
-                  "MMM-YYYY"
-                )}
-                valueStyles={{ fontFamily: "Work Sans" }}
-              />
-            </SummaryCardRow>
-          );
-        })}
-      <SummaryCardFooter linkTo={`${conditionsPath}`} />
-    </SummaryCard>
+    <>
+      {patientConditions && patientConditions.total > 0 ? (
+        displayConditions()
+      ) : (
+        <SummaryCard name="Conditions">
+          <div className={styles.emptyConditions}>
+            <p className="omrs-type-body-regular">No Conditions documented.</p>
+          </div>
+        </SummaryCard>
+      )}
+    </>
   );
 }
 

--- a/src/widgets/conditions/conditions-overview.css
+++ b/src/widgets/conditions/conditions-overview.css
@@ -11,3 +11,9 @@
 .conditionMore p {
   margin: 0;
 }
+
+.emptyConditions p {
+  text-align: left;
+  padding-left: 1rem;
+  font-weight: 500;
+}

--- a/src/widgets/conditions/conditions-overview.test.tsx
+++ b/src/widgets/conditions/conditions-overview.test.tsx
@@ -29,10 +29,11 @@ describe("<ConditionsOverview />", () => {
   });
 
   beforeEach(mockUseCurrentPatient.mockReset);
+  beforeEach(() => {
+    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
+  });
 
   it("should render without dying", async () => {
-    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
-
     mockPerformPatientConditionsSearch.mockResolvedValue(
       mockPatientConditionsResult
     );
@@ -48,7 +49,6 @@ describe("<ConditionsOverview />", () => {
   });
 
   it("should display the patient conditions correctly", async () => {
-    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
     mockPerformPatientConditionsSearch.mockReturnValue(
       Promise.resolve(mockPatientConditionsResult)
     );
@@ -62,6 +62,21 @@ describe("<ConditionsOverview />", () => {
     await wait(() => {
       expect(wrapper.getByText("Hypertension")).toBeTruthy();
       expect(wrapper.getByText("Renal rejection")).toBeTruthy();
+    });
+  });
+
+  it("should not display the patient conditions when conditions are absent", async () => {
+    mockPerformPatientConditionsSearch.mockReturnValue(Promise.resolve(null));
+
+    wrapper = render(
+      <BrowserRouter>
+        <ConditionsOverview match={match} />
+      </BrowserRouter>
+    );
+
+    await wait(() => {
+      expect(wrapper).toBeDefined();
+      expect(wrapper.getByText("No Conditions documented.")).toBeTruthy();
     });
   });
 });

--- a/src/widgets/heightandweight/heightandweight-detailed-summary.component.tsx
+++ b/src/widgets/heightandweight/heightandweight-detailed-summary.component.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import styles from "./heightandweight-detailed-summary.css";
 import dayjs from "dayjs";
-import { getDimenionsObservationsRestAPI } from "./heightandweight.resource";
+import { getDimensionsObservationsRestAPI } from "./heightandweight.resource";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import { isEmpty } from "lodash-es";
 import {
@@ -24,7 +24,7 @@ export default function HeightAndWeightDetailedSummary(
   ] = useCurrentPatient();
 
   useEffect(() => {
-    getDimenionsObservationsRestAPI(patientUuid).subscribe(response => {
+    getDimensionsObservationsRestAPI(patientUuid).subscribe(response => {
       setDimensions(
         response.find(dimension => dimension.obsData.weight.uuid === props.uuid)
       );

--- a/src/widgets/heightandweight/heightandweight-overview.component.tsx
+++ b/src/widgets/heightandweight/heightandweight-overview.component.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
-import { getDimenionsObservationsRestAPI } from "./heightandweight.resource";
+import { getDimensionsObservationsRestAPI } from "./heightandweight.resource";
 import SummaryCardRow from "../../ui-components/cards/summary-card-row.component";
 import SummaryCardRowContent from "../../ui-components/cards/summary-card-row-content.component";
 import styles from "./heightandweight-overview.css";
@@ -21,7 +21,7 @@ export default function HeightAndWeightOverview(
 
   React.useEffect(() => {
     if (patientUuid) {
-      const sub = getDimenionsObservationsRestAPI(patientUuid).subscribe(
+      const sub = getDimensionsObservationsRestAPI(patientUuid).subscribe(
         dimensions => {
           setDimensions(dimensions);
         }
@@ -31,67 +31,91 @@ export default function HeightAndWeightOverview(
     }
   }, [patientUuid]);
 
-  return (
-    <SummaryCard
-      name="Height & Weight"
-      link={`/patient/${patientUuid}/chart/dimensions`}
-    >
-      <SummaryCardRow>
-        <SummaryCardRowContent>
-          <table className={styles.table}>
-            <thead>
-              <tr className={styles.tableRow}>
-                <th
-                  className={`${styles.tableHeader} ${styles.tableDates}`}
-                  style={{ textAlign: "start" }}
-                ></th>
-                <th className={styles.tableHeader}>Weight</th>
-                <th className={styles.tableHeader}>Height</th>
-                <th className={styles.tableHeader}>BMI</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {dimensions.slice(0, showMore ? 6 : 3).map((dimension, index) => (
-                <tr key={dimension.id} className={styles.tableRow}>
-                  <td
-                    className={styles.tableData}
+  function displayDimensions() {
+    return (
+      <SummaryCard
+        name="Height & Weight"
+        link={`/patient/${patientUuid}/chart/dimensions`}
+      >
+        <SummaryCardRow>
+          <SummaryCardRowContent>
+            <table className={styles.table}>
+              <thead>
+                <tr className={styles.tableRow}>
+                  <th
+                    className={`${styles.tableHeader} ${styles.tableDates}`}
                     style={{ textAlign: "start" }}
-                  >
-                    {dimension.date}
-                  </td>
-                  <td className={styles.tableData}>
-                    {dimension.weight || "\u2014"}
-                    <span className={styles.unit}>{index === 0 && " kg"}</span>
-                  </td>
-                  <td className={styles.tableData}>
-                    {dimension.height || "\u2014"}
-                    <span className={styles.unit}>{index === 0 && " cm"}</span>
-                  </td>
-                  <td className={styles.tableData}>
-                    {dimension.bmi || "\u2014"}
-                    {}
-                    <span className={styles.unit}>
-                      {index === 0 && " kg/m"}
-                      {index === 0 && <sup>2</sup>}
-                    </span>
-                  </td>
-                  <td style={{ textAlign: "end" }}>
-                    <svg
-                      className="omrs-icon"
-                      fill="var(--omrs-color-ink-low-contrast)"
-                    >
-                      <use xlinkHref="#omrs-icon-chevron-right" />
-                    </svg>
-                  </td>
+                  ></th>
+                  <th className={styles.tableHeader}>Weight</th>
+                  <th className={styles.tableHeader}>Height</th>
+                  <th className={styles.tableHeader}>BMI</th>
+                  <th></th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </SummaryCardRowContent>
-      </SummaryCardRow>
-      <SummaryCardFooter linkTo={`/patient/${patientUuid}/chart/dimensions`} />
-    </SummaryCard>
+              </thead>
+              <tbody>
+                {dimensions
+                  .slice(0, showMore ? 6 : 3)
+                  .map((dimension, index) => (
+                    <tr key={dimension.id} className={styles.tableRow}>
+                      <td
+                        className={styles.tableData}
+                        style={{ textAlign: "start" }}
+                      >
+                        {dimension.date}
+                      </td>
+                      <td className={styles.tableData}>
+                        {dimension.weight || "\u2014"}
+                        <span className={styles.unit}>
+                          {index === 0 && " kg"}
+                        </span>
+                      </td>
+                      <td className={styles.tableData}>
+                        {dimension.height || "\u2014"}
+                        <span className={styles.unit}>
+                          {index === 0 && " cm"}
+                        </span>
+                      </td>
+                      <td className={styles.tableData}>
+                        {dimension.bmi || "\u2014"}
+                        {}
+                        <span className={styles.unit}>
+                          {index === 0 && " kg/m"}
+                          {index === 0 && <sup>2</sup>}
+                        </span>
+                      </td>
+                      <td style={{ textAlign: "end" }}>
+                        <svg
+                          className="omrs-icon"
+                          fill="var(--omrs-color-ink-low-contrast)"
+                        >
+                          <use xlinkHref="#omrs-icon-chevron-right" />
+                        </svg>
+                      </td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </SummaryCardRowContent>
+        </SummaryCardRow>
+        <SummaryCardFooter
+          linkTo={`/patient/${patientUuid}/chart/dimensions`}
+        />
+      </SummaryCard>
+    );
+  }
+
+  return (
+    <>
+      {dimensions && dimensions.length ? (
+        displayDimensions()
+      ) : (
+        <SummaryCard name="Height & Weight">
+          <div className={styles.emptyDimensions}>
+            <p className="omrs-type-body-regular">No Dimensions recorded.</p>
+          </div>
+        </SummaryCard>
+      )}
+    </>
   );
 }
 

--- a/src/widgets/heightandweight/heightandweight-overview.css
+++ b/src/widgets/heightandweight/heightandweight-overview.css
@@ -34,10 +34,18 @@
   width: 21.75rem;
   margin: 0.5rem 1rem;
 }
+
 .card {
   width: 40rem;
   margin: 0.5rem 1rem;
 }
+
 .unit {
   color: var(--omrs-color-ink-medium-contrast);
+}
+
+.emptyDimensions p {
+  text-align: left;
+  padding-left: 1rem;
+  font-weight: 500;
 }

--- a/src/widgets/heightandweight/heightandweight-overview.test.tsx
+++ b/src/widgets/heightandweight/heightandweight-overview.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { cleanup, render, wait } from "@testing-library/react";
+import HeightAndWeightOverview from "./heightandweight-overview.component";
+import { useCurrentPatient } from "@openmrs/esm-api";
+import { getDimensionsObservationsRestAPI } from "./heightandweight.resource";
+import { mockPatient } from "../../../__mocks__/patient.mock";
+import { of } from "rxjs/internal/observable/of";
+import { BrowserRouter } from "react-router-dom";
+import { mockHeightAndWeightResponse } from "../../../__mocks__/height-and-weight.mock";
+
+const mockUseCurrentPatient = useCurrentPatient as jest.Mock;
+const mockGetDimensionsObservableRestAPI = getDimensionsObservationsRestAPI as jest.Mock;
+
+jest.mock("./heightandweight.resource", () => ({
+  getDimensionsObservationsRestAPI: jest.fn()
+}));
+
+jest.mock("@openmrs/esm-api", () => ({
+  useCurrentPatient: jest.fn()
+}));
+
+let wrapper;
+
+describe("<HeightAndWeightOverview/>", () => {
+  afterEach(cleanup);
+
+  beforeEach(mockGetDimensionsObservableRestAPI.mockReset);
+  beforeEach(() => {
+    mockUseCurrentPatient.mockReturnValue([
+      false,
+      mockPatient,
+      mockPatient.id,
+      null
+    ]);
+  });
+
+  it("renders without dying", async () => {
+    mockGetDimensionsObservableRestAPI.mockReturnValue(
+      of(mockHeightAndWeightResponse)
+    );
+
+    wrapper = render(
+      <BrowserRouter>
+        <HeightAndWeightOverview />
+      </BrowserRouter>
+    );
+
+    expect(wrapper).toBeDefined();
+  });
+
+  it("displays the patient's dimensions correctly", async () => {
+    mockGetDimensionsObservableRestAPI.mockReturnValue(
+      of(mockHeightAndWeightResponse)
+    );
+
+    wrapper = render(
+      <BrowserRouter>
+        <HeightAndWeightOverview />
+      </BrowserRouter>
+    );
+
+    expect(wrapper.getByText("Weight").textContent).toBeDefined();
+    expect(wrapper.getByText("Height").textContent).toBeDefined();
+    expect(wrapper.getByText("BMI").textContent).toBeDefined();
+    expect(wrapper.getByText("13-Jan 10:35 AM").textContent).toBeDefined();
+    expect(wrapper.getByText("13-Jan 10:30 AM").textContent).toBeDefined();
+    expect(wrapper.getByText("13-Jan 10:20 AM").textContent).toBeDefined();
+  });
+
+  it("should not display the patient's dimensions when dimensions data is absent", async () => {
+    mockGetDimensionsObservableRestAPI.mockReturnValue(of(null));
+
+    wrapper = render(
+      <BrowserRouter>
+        <HeightAndWeightOverview />
+      </BrowserRouter>
+    );
+
+    await wait(() => {
+      expect(wrapper).toBeDefined();
+      expect(
+        wrapper.getByText("No Dimensions recorded.").textContent
+      ).toBeTruthy();
+    });
+  });
+});

--- a/src/widgets/heightandweight/heightandweight-summary.component.tsx
+++ b/src/widgets/heightandweight/heightandweight-summary.component.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import styles from "./heightandweight-summary.css";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
-import { getDimenionsObservationsRestAPI } from "./heightandweight.resource";
 import { useCurrentPatient, newWorkspaceItem } from "@openmrs/esm-api";
+import { getDimensionsObservationsRestAPI } from "./heightandweight.resource";
 import { Link } from "react-router-dom";
 import VitalsForm from "../vitals/vitals-form.component";
 
@@ -17,7 +17,7 @@ function HeightAndWeightSummary(props: HeightAndWeightSummaryProps) {
 
   React.useEffect(() => {
     if (patientUuid) {
-      const sub = getDimenionsObservationsRestAPI(
+      const sub = getDimensionsObservationsRestAPI(
         patientUuid
       ).subscribe(dimensions => setDimensions(dimensions));
       return () => sub.unsubscribe();

--- a/src/widgets/heightandweight/heightandweight.resource.ts
+++ b/src/widgets/heightandweight/heightandweight.resource.ts
@@ -32,7 +32,7 @@ const WEIGHT_CONCEPT = "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 //   );
 // }
 
-export function getDimenionsObservationsRestAPI(patientUuid: string) {
+export function getDimensionsObservationsRestAPI(patientUuid: string) {
   return openmrsObservableFetch(
     `/ws/rest/v1/obs?concepts=${WEIGHT_CONCEPT},${HEIGHT_CONCEPT}&patient=${patientUuid}&v=custom:(uuid,display,obsDatetime,encounter:(encounterDatetime),value,concept:(uuid))`
   ).pipe(

--- a/src/widgets/medications/medications-overview.css
+++ b/src/widgets/medications/medications-overview.css
@@ -1,6 +1,7 @@
 .medicationsTable {
   width: 100%;
 }
+
 .medicationsTable thead td {
   padding: 1rem 0.25rem 1rem 1rem;
 }
@@ -36,4 +37,14 @@
 
 .medicationsFooter svg {
   margin-right: 0.5rem;
+}
+
+.medicationStatement {
+  text-transform: lowercase;
+}
+
+.emptyMedications p {
+  text-align: left;
+  padding-left: 1rem;
+  font-weight: 500;
 }

--- a/src/widgets/medications/medications-overview.test.tsx
+++ b/src/widgets/medications/medications-overview.test.tsx
@@ -3,9 +3,9 @@ import { mockPatient } from "../../../__mocks__/patient.mock";
 import { mockFetchPatientMedicationsResponse } from "../../../__mocks__/medication.mock";
 import { cleanup, render, wait } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
+import MedicationsOverview from "./medications-overview.component";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import { fetchPatientMedications } from "./medications.resource";
-import MedicationsOverview from "./medications-overview.component";
 import { of } from "rxjs/internal/observable/of";
 
 const mockUseCurrentPatient = useCurrentPatient as jest.Mock;
@@ -24,16 +24,17 @@ let wrapper;
 describe("<MedicationsOverview/>", () => {
   afterEach(cleanup);
 
-  beforeEach(mockFetchPatientMedications.mockReset);
-
-  it("renders without dying", async () => {
+  beforeEach(() => {
     mockUseCurrentPatient.mockReturnValue([
       false,
       mockPatient,
       mockPatient.id,
       null
     ]);
+    mockFetchPatientMedications.mockReset;
+  });
 
+  it("renders without dying", async () => {
     mockFetchPatientMedications.mockReturnValue(
       of(mockFetchPatientMedicationsResponse)
     );
@@ -50,13 +51,6 @@ describe("<MedicationsOverview/>", () => {
   });
 
   it("should display the patients medications correctly", async () => {
-    mockUseCurrentPatient.mockReturnValue([
-      false,
-      mockPatient,
-      mockPatient.id,
-      null
-    ]);
-
     mockFetchPatientMedications.mockReturnValue(
       of(mockFetchPatientMedicationsResponse)
     );
@@ -69,16 +63,35 @@ describe("<MedicationsOverview/>", () => {
 
     await wait(() => {
       expect(wrapper).toBeDefined();
-      expect(wrapper.getAllByText("Active Medications").length).toEqual(2);
+      expect(wrapper.getByText("Active Medications").textContent).toBeTruthy();
+      expect(wrapper.getByText("Add").textContent).toBeTruthy();
       expect(wrapper.getByText("sulfadoxine").textContent).toBeTruthy();
       expect(wrapper.getByText("DOSE").textContent).toBeTruthy();
       expect(wrapper.getByText("500 mg").textContent).toBeTruthy();
       expect(wrapper.getByText("capsule").textContent).toBeTruthy();
       expect(wrapper.getByText("oral").textContent).toBeTruthy();
       expect(wrapper.getByText(/Twice daily/).textContent).toBeTruthy();
-      expect(wrapper.getByText("Revise").textContent).toBeTruthy();
-      expect(wrapper.getByText("Discontinue").textContent).toBeTruthy();
-      expect(wrapper.getByText("See all").textContent).toBeTruthy();
+      expect(wrapper.getByText("Revise")).toBeTruthy();
+      expect(wrapper.getByText("Discontinue")).toBeTruthy();
+      expect(wrapper.getByText("See all")).toBeTruthy();
+    });
+  });
+
+  it("should not display the patient medications when medications are absent", async () => {
+    mockFetchPatientMedications.mockReturnValue(of([]));
+
+    wrapper = render(
+      <BrowserRouter>
+        <MedicationsOverview basePath="/" />
+      </BrowserRouter>
+    );
+
+    await wait(() => {
+      expect(wrapper).toBeDefined();
+      expect(wrapper.getByText("Active Medications").textContent).toBeTruthy();
+      expect(
+        wrapper.getByText("No Active Medications recorded.").textContent
+      ).toBeTruthy();
     });
   });
 });

--- a/src/widgets/notes/notes-overview.component.tsx
+++ b/src/widgets/notes/notes-overview.component.tsx
@@ -141,7 +141,21 @@ export default function NotesOverview(props: NotesOverviewProps) {
     );
   }
 
-  return restAPINotesOverview();
+  return (
+    <>
+      <div>
+        {patientNotes ? (
+          restAPINotesOverview()
+        ) : (
+          <SummaryCard name="Notes">
+            <div className={styles.emptyNotes}>
+              <p className="omrs-type-body-regular">No Notes documented.</p>
+            </div>
+          </SummaryCard>
+        )}
+      </div>
+    </>
+  );
 }
 
 type NotesOverviewProps = {

--- a/src/widgets/notes/notes-overview.css
+++ b/src/widgets/notes/notes-overview.css
@@ -35,3 +35,9 @@
 .noteAuthor {
   text-align: left;
 }
+
+.emptyNotes p {
+  text-align: left;
+  padding-left: 1rem;
+  font-weight: 500;
+}

--- a/src/widgets/programs/programs-overview.component.tsx
+++ b/src/widgets/programs/programs-overview.component.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import dayjs from "dayjs";
+import styles from "./programs-overview.css";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import SummaryCardRow from "../../ui-components/cards/summary-card-row.component";
 import SummaryCardRowContent from "../../ui-components/cards/summary-card-row-content.component";
@@ -50,50 +51,68 @@ export default function ProgramsOverview(props: ProgramsOverviewProps) {
     });
   };
 
+  function displayCarePrograms() {
+    return (
+      <SummaryCard
+        name={t("care programs", "Care Programs")}
+        link={`/patient/${patientUuid}/chart/programs`}
+        styles={{ margin: "1.25rem, 1.5rem" }}
+        addComponent={ProgramsForm}
+        showComponent={() =>
+          openProgramsWorkspaceTab(ProgramsForm, "Programs Form")
+        }
+      >
+        <SummaryCardRow>
+          <SummaryCardRowContent>
+            <HorizontalLabelValue
+              label={t("Active Programs", "Active Programs")}
+              labelStyles={{
+                color: "var(--omrs-color-ink-medium-contrast)",
+                fontFamily: "Work Sans"
+              }}
+              value={t("Since", "Since")}
+              valueStyles={{
+                color: "var(--omrs-color-ink-medium-contrast)",
+                fontFamily: "Work Sans"
+              }}
+            />
+          </SummaryCardRowContent>
+        </SummaryCardRow>
+        {patientPrograms &&
+          patientPrograms.map(program => {
+            return (
+              <SummaryCardRow
+                key={program.uuid}
+                linkTo={`${programsPath}/${program.uuid}`}
+              >
+                <HorizontalLabelValue
+                  label={program.display}
+                  labelStyles={{ fontWeight: 500 }}
+                  value={dayjs(program.dateEnrolled).format("MMM-YYYY")}
+                  valueStyles={{ fontFamily: "Work Sans" }}
+                />
+              </SummaryCardRow>
+            );
+          })}
+        <SummaryCardFooter linkTo={`${programsPath}`} />
+      </SummaryCard>
+    );
+  }
+
   return (
-    <SummaryCard
-      name={t("care programs", "Care Programs")}
-      link={programsPath}
-      styles={{ margin: "1.25rem, 1.5rem" }}
-      addComponent={ProgramsForm}
-      showComponent={() =>
-        openProgramsWorkspaceTab(ProgramsForm, "Programs Form")
-      }
-    >
-      <SummaryCardRow>
-        <SummaryCardRowContent>
-          <HorizontalLabelValue
-            label={t("Active Programs", "Active Programs")}
-            labelStyles={{
-              color: "var(--omrs-color-ink-medium-contrast)",
-              fontFamily: "Work Sans"
-            }}
-            value={t("Since", "Since")}
-            valueStyles={{
-              color: "var(--omrs-color-ink-medium-contrast)",
-              fontFamily: "Work Sans"
-            }}
-          />
-        </SummaryCardRowContent>
-      </SummaryCardRow>
-      {patientPrograms &&
-        patientPrograms.map(program => {
-          return (
-            <SummaryCardRow
-              key={program.uuid}
-              linkTo={`${programsPath}/${program.uuid}`}
-            >
-              <HorizontalLabelValue
-                label={program.display}
-                labelStyles={{ fontWeight: 500 }}
-                value={dayjs(program.dateEnrolled).format("MMM-YYYY")}
-                valueStyles={{ fontFamily: "Work Sans" }}
-              />
-            </SummaryCardRow>
-          );
-        })}
-      <SummaryCardFooter linkTo={`${programsPath}`} />
-    </SummaryCard>
+    <>
+      {patientPrograms && patientPrograms.length ? (
+        displayCarePrograms()
+      ) : (
+        <SummaryCard name={t("care programs", "Care Programs")}>
+          <div className={styles.emptyPrograms}>
+            <p className="omrs-type-body-regular">
+              No Program enrollments recorded.
+            </p>
+          </div>
+        </SummaryCard>
+      )}
+    </>
   );
 }
 

--- a/src/widgets/programs/programs-overview.css
+++ b/src/widgets/programs/programs-overview.css
@@ -1,0 +1,5 @@
+.emptyPrograms p {
+  text-align: left;
+  padding-left: 1rem;
+  font-weight: 500;
+}

--- a/src/widgets/programs/programs-overview.test.tsx
+++ b/src/widgets/programs/programs-overview.test.tsx
@@ -43,4 +43,23 @@ describe("<ProgramsOverview />", () => {
       spy.mockRestore();
     });
   });
+
+  it("should not display enrollments when the patient is not enrolled into any programs", async () => {
+    const spy = jest.spyOn(openmrsApi, "openmrsObservableFetch");
+    spy.mockReturnValue(of(null));
+
+    const wrapper = render(
+      <BrowserRouter>
+        <ProgramsOverview />
+      </BrowserRouter>
+    );
+
+    await wait(() => {
+      expect(wrapper.getByText(/Care Programs/i).textContent).toBeDefined();
+      expect(
+        wrapper.getByText("No Program enrollments recorded.")
+      ).toBeDefined();
+      spy.mockRestore();
+    });
+  });
 });

--- a/src/widgets/vitals/vitals-overview.component.tsx
+++ b/src/widgets/vitals/vitals-overview.component.tsx
@@ -25,59 +25,75 @@ export default function VitalsOverview(props: VitalsOverviewProps) {
     return () => subscription.unsubscribe();
   }, [patientUuid]);
 
+  function displayVitals() {
+    return (
+      <SummaryCard
+        name="Vitals"
+        styles={{ width: "100%" }}
+        link={`/patient/${patientUuid}/chart/vitals`}
+      >
+        <table className={styles.vitalsTable}>
+          <thead>
+            <tr className="omrs-bold">
+              <td></td>
+              <td>BP</td>
+              <td>Rate</td>
+              <td>Oxygen</td>
+              <td colSpan={2}>Temp</td>
+            </tr>
+          </thead>
+          <tbody>
+            {patientVitals &&
+              patientVitals.map((vitals, index) => {
+                return (
+                  <React.Fragment key={vitals.id}>
+                    <tr>
+                      <td>{formatDate(vitals.date)}</td>
+                      <td>
+                        {`${vitals.systolic} / ${vitals.diastolic}`}
+                        {index === 0 && <span> mmHg</span>}
+                      </td>
+                      <td>
+                        {vitals.pulse} {index === 0 && <span>bpm</span>}
+                      </td>
+                      <td>
+                        {vitals.oxygenation} {index === 0 && <span>%</span>}
+                      </td>
+                      <td>
+                        {vitals.temperature}
+                        {index === 0 && <span> &#8451;</span>}
+                      </td>
+                      <td>
+                        <svg
+                          className="omrs-icon"
+                          fill="var(--omrs-color-ink-low-contrast)"
+                        >
+                          <use xlinkHref="#omrs-icon-chevron-right" />
+                        </svg>
+                      </td>
+                    </tr>
+                  </React.Fragment>
+                );
+              })}
+          </tbody>
+        </table>
+        <SummaryCardFooter linkTo={`/patient/${patientUuid}/chart/vitals`} />
+      </SummaryCard>
+    );
+  }
+
   return (
-    <SummaryCard
-      name="Vitals"
-      styles={{ width: "100%" }}
-      link={`/patient/${patientUuid}/chart/vitals`}
-    >
-      <table className={styles.vitalsTable}>
-        <thead>
-          <tr className="omrs-bold">
-            <td></td>
-            <td>BP</td>
-            <td>Rate</td>
-            <td>Oxygen</td>
-            <td colSpan={2}>Temp</td>
-          </tr>
-        </thead>
-        <tbody>
-          {patientVitals &&
-            patientVitals.splice(0, 3).map((vitals, index) => {
-              return (
-                <React.Fragment key={vitals.id}>
-                  <tr>
-                    <td>{formatDate(vitals.date)}</td>
-                    <td>
-                      {`${vitals.systolic} / ${vitals.diastolic}`}
-                      {index === 0 && <span> mmHg</span>}
-                    </td>
-                    <td>
-                      {vitals.pulse} {index === 0 && <span>bpm</span>}
-                    </td>
-                    <td>
-                      {vitals.oxygenation} {index === 0 && <span>%</span>}
-                    </td>
-                    <td>
-                      {vitals.temperature}
-                      {index === 0 && <span> &#8451;</span>}
-                    </td>
-                    <td>
-                      <svg
-                        className="omrs-icon"
-                        fill="var(--omrs-color-ink-low-contrast)"
-                      >
-                        <use xlinkHref="#omrs-icon-chevron-right" />
-                      </svg>
-                    </td>
-                  </tr>
-                </React.Fragment>
-              );
-            })}
-        </tbody>
-      </table>
-      <SummaryCardFooter linkTo={`/patient/${patientUuid}/chart/vitals`} />
-    </SummaryCard>
+    <>
+      {patientVitals && patientVitals.length ? (
+        displayVitals()
+      ) : (
+        <SummaryCard name="Vitals">
+          <div className={styles.emptyVitals}>
+            <p className="omrs-type-body-regular">No Vitals documented.</p>
+          </div>
+        </SummaryCard>
+      )}
+    </>
   );
 }
 

--- a/src/widgets/vitals/vitals-overview.css
+++ b/src/widgets/vitals/vitals-overview.css
@@ -37,3 +37,9 @@
 .vitalsFooter svg {
   margin-right: 0.5rem;
 }
+
+.emptyVitals p {
+  text-align: left;
+  padding-left: 1rem;
+  font-weight: 500;
+}

--- a/src/widgets/vitals/vitals-overview.test.tsx
+++ b/src/widgets/vitals/vitals-overview.test.tsx
@@ -27,6 +27,23 @@ describe("<VitalsOverview/>", () => {
     );
   });
 
+  it("should not display the patient's vitals when vitals are absent", async () => {
+    const spy = jest.spyOn(openmrsApi, "openmrsObservableFetch");
+    spy.mockReturnValue(of(null));
+
+    const wrapper = render(
+      <BrowserRouter>
+        <VitalsOverview />
+      </BrowserRouter>
+    );
+
+    await wait(() => {
+      expect(wrapper.getByText("Vitals").textContent).toBeDefined();
+      expect(wrapper.getByText("No Vitals documented.")).toBeDefined();
+      spy.mockRestore();
+    });
+  });
+
   //   it("should display the patients vitals correctly", async () => {
   //     const spy = jest.spyOn(openmrsApi, "openmrsObservableFetch");
   //     spy.mockReturnValue(of(mockVitalsResponse));

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,6 +1,11 @@
 {
+  "Active Medications": "Active Medications",
   "Active Programs": "Active Programs",
+  "Medications - current": "Medications - current",
+  "Medications - past": "Medications - past",
   "Notes": "Notes",
   "Since": "Since",
-  "care programs": "Care Programs"
+  "care programs": "Care Programs",
+  "conditions": "Conditions",
+  "vitals": "Vitals"
 }


### PR DESCRIPTION
This PR introduces an alternative view which is rendered when widgets do not have data to display.

Presently, most widgets will render an incomplete view - in the case of the Notes widget, table headers will be displayed without the corresponding table data.

<img width="1399" alt="Screenshot 2020-03-03 at 21 04 11" src="https://user-images.githubusercontent.com/8509731/76059503-13c79e00-5f90-11ea-9a98-a0810c1cd360.png">
 
This could be improved upon by rendering something that communicates that the patient does not have recorded patient notes and perhaps a link to a view where patient notes could be added.

<img width="1395" alt="Screenshot 2020-03-03 at 21 13 29" src="https://user-images.githubusercontent.com/8509731/76059567-3ce82e80-5f90-11ea-9a80-ca228c87f777.png">

This is how the patient chart would look if all the widgets did not have data:

<img width="1792" alt="Screenshot 2020-03-04 at 12 15 12" src="https://user-images.githubusercontent.com/8509731/76059359-b3d0f780-5f8f-11ea-8ac5-05eb80f50a85.png">
