### PR TITLE
Make workspace item launchable from widgets

### DIFF
--- a/src/ui-components/cards/summary-card.component.tsx
+++ b/src/ui-components/cards/summary-card.component.tsx
@@ -1,7 +1,7 @@
 import React, { ReactChildren } from "react";
 import styles from "./summary-card.css";
 import { Link } from "react-router-dom";
-//import { newWorkspaceItem } from "@openmrs/esm-api";
+//import { newWorkspaceItem } from "@openmrs-esm-api";
 import { Trans, useTranslation } from "react-i18next";
 
 export default function SummaryCard(props: SummaryCardProps) {
@@ -55,16 +55,6 @@ export default function SummaryCard(props: SummaryCardProps) {
     );
   }
 }
-/*
-function showComponent(component, name): void {
-  newWorkspaceItem({
-    component: component,
-    name: name,
-    props: { match: { params: {} } },
-    inProgress: false
-  });
-}
-*/
 
 type SummaryCardProps = {
   name: string;

--- a/src/widgets/heightandweight/heightandweight-summary.component.tsx
+++ b/src/widgets/heightandweight/heightandweight-summary.component.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styles from "./heightandweight-summary.css";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import { getDimenionsObservationsRestAPI } from "./heightandweight.resource";
-import { useCurrentPatient } from "@openmrs/esm-api";
+import { useCurrentPatient, newWorkspaceItem } from "@openmrs/esm-api";
 import { Link } from "react-router-dom";
 import VitalsForm from "../vitals/vitals-form.component";
 
@@ -24,6 +24,19 @@ function HeightAndWeightSummary(props: HeightAndWeightSummaryProps) {
     }
   }, [patientUuid]);
 
+  const openHeightAndWeightTab = (addComponent, componentName): void => {
+    newWorkspaceItem({
+      component: addComponent,
+      name: componentName,
+      props: {
+        match: { params: {} }
+      },
+      inProgress: false,
+      validations: (workspaceTabs: any[]) =>
+        workspaceTabs.findIndex(tab => tab.component === addComponent)
+    });
+  };
+
   return (
     <div
       style={{
@@ -36,6 +49,7 @@ function HeightAndWeightSummary(props: HeightAndWeightSummaryProps) {
         name="Height & Weight"
         styles={{ flex: 1, margin: ".5rem" }}
         addComponent={VitalsForm}
+        showComponent={() => openHeightAndWeightTab(VitalsForm, "Vitals Form")}
       >
         <table className={styles.table}>
           <thead>

--- a/src/widgets/medications/medication-level-two.component.tsx
+++ b/src/widgets/medications/medication-level-two.component.tsx
@@ -7,7 +7,10 @@ import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import { useTranslation } from "react-i18next";
 import dayjs from "dayjs";
-import { getDosage } from "./medication-orders-utils";
+import {
+  getDosage,
+  openMedicationWorkspaceTab
+} from "./medication-orders-utils";
 import { Link } from "react-router-dom";
 import { MedicationButton } from "./medication-button.component";
 import MedicationOrderBasket from "./medication-order-basket.component";
@@ -39,6 +42,12 @@ export default function MedicationLevelTwo(props: MedicationsOverviewProps) {
         <SummaryCard
           name={t("Medications - current", "Medications - current")}
           addComponent={MedicationOrderBasket}
+          showComponent={() =>
+            openMedicationWorkspaceTab(
+              MedicationOrderBasket,
+              "Medication Order"
+            )
+          }
         >
           <table className={styles.medicationsTable}>
             <thead>
@@ -94,7 +103,7 @@ export default function MedicationLevelTwo(props: MedicationsOverviewProps) {
                               {" \u2014 "} {medication.frequency.display}
                               {" \u2014 "}
                               {medication.duration}
-                              {medication.durationUnits.display}
+                              {medication.durationUnits?.display}
                               {" \u2014 "}
                             </span>
                             &nbsp;&nbsp;
@@ -171,6 +180,12 @@ export default function MedicationLevelTwo(props: MedicationsOverviewProps) {
         <SummaryCard
           name={t("Medications - past", "Medications - past")}
           addComponent={MedicationOrderBasket}
+          showComponent={() =>
+            openMedicationWorkspaceTab(
+              MedicationOrderBasket,
+              "Medication Order"
+            )
+          }
         >
           <table className={styles.medicationsTable}>
             <thead>

--- a/src/widgets/medications/medication-orders-utils.ts
+++ b/src/widgets/medications/medication-orders-utils.ts
@@ -1,3 +1,5 @@
+import { newWorkspaceItem } from "@openmrs/esm-api";
+
 export function getDosage(strength, doseNumber) {
   const i = strength.search(/\D/);
   const strengthQuantity = strength.substring(0, i);
@@ -64,6 +66,24 @@ export function setDefaultValues(commonDrugOrders) {
   ];
 }
 
+export const openMedicationWorkspaceTab = (componentName, title) => {
+  newWorkspaceItem({
+    component: componentName,
+    name: title,
+    props: {
+      match: {
+        params: {
+          orderUuid: null,
+          drugName: null,
+          action: "NEW"
+        }
+      }
+    },
+    inProgress: false,
+    validations: (workspaceTabs: any[]) =>
+      workspaceTabs.findIndex(tab => tab.component === componentName)
+  });
+};
 export type OrderMedication = {
   patientUuid: string;
   careSetting: string;

--- a/src/widgets/medications/medications-overview.component.tsx
+++ b/src/widgets/medications/medications-overview.component.tsx
@@ -3,10 +3,13 @@ import SummaryCard from "../../ui-components/cards/summary-card.component";
 import { fetchPatientMedications } from "./medications.resource";
 import styles from "./medications-overview.css";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
-import { useCurrentPatient } from "@openmrs/esm-api";
+import { useCurrentPatient, newWorkspaceItem } from "@openmrs/esm-api";
 import SummaryCardFooter from "../../ui-components/cards/summary-card-footer.component";
 import { useTranslation } from "react-i18next";
-import { getDosage } from "./medication-orders-utils";
+import {
+  getDosage,
+  openMedicationWorkspaceTab
+} from "./medication-orders-utils";
 import { Link } from "react-router-dom";
 import MedicationOrderBasket from "./medication-order-basket.component";
 import { MedicationButton } from "./medication-button.component";
@@ -36,7 +39,10 @@ export default function MedicationsOverview(props: MedicationsOverviewProps) {
     <SummaryCard
       name={t("Active Medications", "Active Medications")}
       styles={{ width: "100%" }}
-      link={`/patient/${patientUuid}/chart/Medications`}
+      addComponent={MedicationOrderBasket}
+      showComponent={() =>
+        openMedicationWorkspaceTab(MedicationOrderBasket, "Medication Order")
+      }
     >
       <table className={styles.medicationsTable}>
         <tbody>{patientMedications && parseRestWsMeds()}</tbody>

--- a/src/widgets/vitals/vitals-detailed-summary.component.tsx
+++ b/src/widgets/vitals/vitals-detailed-summary.component.tsx
@@ -72,14 +72,18 @@ export default function VitalsDetailedSummary(
     setCurrentPage(currentPage - 1);
   };
 
-  function openVitalsWorkspaceTab() {
+  const openVitalsWorkspaceTab = (componentToAdd, componentName) => {
     newWorkspaceItem({
-      component: VitalsForm,
-      name: "Vitals",
-      props: { match: { params: {} } },
-      inProgress: false
+      component: componentToAdd,
+      name: componentName,
+      props: {
+        match: { params: {} }
+      },
+      inProgress: false,
+      validations: (workspaceTabs: any[]) =>
+        workspaceTabs.findIndex(tab => tab.component === componentToAdd)
     });
-  }
+  };
 
   function displayPatientsVitals() {
     return (
@@ -171,10 +175,14 @@ export default function VitalsDetailedSummary(
           border: "none"
         }}
         addComponent={VitalsForm}
+        showComponent={() => openVitalsWorkspaceTab(VitalsForm, "Vitals Form")}
       >
         <div className={`${styles.vitalsAbsent} omrs-bold`}>
           <p>No Vitals are documented</p>
-          <button className="omrs-unstyled" onClick={openVitalsWorkspaceTab}>
+          <button
+            className="omrs-unstyled"
+            onClick={() => openVitalsWorkspaceTab(VitalsForm, "Vitals Form")}
+          >
             Add
           </button>
           {` `} new set of vitals.

--- a/src/widgets/vitals/vitals-form.component.tsx
+++ b/src/widgets/vitals/vitals-form.component.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { match, useRouteMatch } from "react-router";
+import { match, useRouteMatch, useHistory } from "react-router-dom";
 import styles from "./vitals-form.css";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import { useCurrentPatient } from "@openmrs/esm-api";
@@ -12,7 +12,6 @@ import {
 import dayjs from "dayjs";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { difference } from "lodash-es";
-import { useHistory } from "react-router-dom";
 
 export default function VitalsForm(props: vitalsFormProp) {
   const [enableButtons, setEnableButtons] = useState(false);


### PR DESCRIPTION
This PR adds functionality to open workspace tabs from within the widget component by passing props. At the moment it bugs out when you click at the add buttons from the widget.
![bugVitals](https://user-images.githubusercontent.com/28008754/76299098-8ce62e80-62cb-11ea-8dbc-2e4585ac77ad.gif)
:point_up:  the bug 
![bugFixVitals](https://user-images.githubusercontent.com/28008754/76299216-bd2dcd00-62cb-11ea-8ca3-018f19f0479a.gif)
:point_up: The fix