### PR TITLE
Fix workspace tabs component key warning

### DIFF
--- a/src/ui-components/tabs/tabs.component.tsx
+++ b/src/ui-components/tabs/tabs.component.tsx
@@ -13,6 +13,7 @@ export function Tabs(props) {
           props.children.map((elem, index) => {
             return (
               <div
+                key={index}
                 className={`${
                   index == props.selected ? styles.selected : styles.unselected
                 }`}


### PR DESCRIPTION
This PR fixes console warning message as shown below
![Screenshot from 2020-03-10 23-04-45](https://user-images.githubusercontent.com/28008754/76354492-98654400-6323-11ea-9d7b-70a4c0fe33f1.png)
