### PR TITLE
Fix property access error when rendering notes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,7 @@
     ],
     "plugins": [
       "@babel/plugin-proposal-class-properties",
+      "@babel/plugin-proposal-optional-chaining",
       ["i18next-extract", {
         "outputPath": "translations/{{locale}}.json",
         "discardOldKeys": true,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.6",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/plugin-proposal-optional-chaining": "^7.8.3",
     "@babel/preset-env": "^7.8.6",
     "@babel/preset-react": "^7.8.3",
     "@babel/preset-typescript": "^7.8.3",

--- a/src/widgets/notes/notes-overview.component.tsx
+++ b/src/widgets/notes/notes-overview.component.tsx
@@ -51,12 +51,12 @@ export default function NotesOverview(props: NotesOverviewProps) {
               patientNotes.slice(0, 5).map(note => (
                 <tr key={note.id} className={styles.tableNotesRow}>
                   <td className={styles.tableNotesDate}>
-                    {formatNotesDate(note.location[0].period.end)}
+                    {formatNotesDate(note?.location[0].period.end)}
                   </td>
                   <td className={styles.tableNotesData}>
-                    {note.type[0].coding[0].display || "\u2014"}
+                    {note?.type[0]?.coding[0]?.display || "\u2014"}
                     <div className={styles.location}>
-                      {note.location[0].location.display || "\u2014"}
+                      {note?.location[0]?.location?.display || "\u2014"}
                     </div>
                   </td>
                   <td className={styles.tableNotesAuthor}>
@@ -104,16 +104,20 @@ export default function NotesOverview(props: NotesOverviewProps) {
               patientNotes.slice(0, 5).map(note => (
                 <tr key={note.uuid} className={styles.tableNotesRow}>
                   <td className={styles.tableNotesDate}>
-                    {formatNotesDate(note.encounterDatetime)}
+                    {formatNotesDate(note?.encounterDatetime)}
                   </td>
                   <td className={styles.tableNotesData}>
-                    {note.encounterType.name}
-                    <div className={styles.location}>{note.location.name}</div>
+                    {note?.encounterType?.name}
+                    <div className={styles.location}>
+                      {note?.location?.name}
+                    </div>
                   </td>
                   <td className={styles.tableNotesAuthor}>
-                    {note.auditInfo.creator
-                      ? String(note.auditInfo.creator.display).toUpperCase()
-                      : String(note.auditInfo.changedBy.display).toUpperCase()}
+                    {note?.auditInfo?.creator
+                      ? String(note?.auditInfo?.creator?.display).toUpperCase()
+                      : String(
+                          note?.auditInfo?.changedBy?.display
+                        ).toUpperCase()}
                   </td>
                   <td
                     className={styles.tdLowerSvg}


### PR DESCRIPTION
Fix issue where patient chart doesn't load when a patient has a note without a location property by using optional chaining to check for that and other deeply nested properties. 