### PR TITLE
Follow-up fixes for the Conditions widget

### DIFF
--- a/src/openmrs-esm-patient-chart-widgets.tsx
+++ b/src/openmrs-esm-patient-chart-widgets.tsx
@@ -30,7 +30,7 @@ export { default as AppointmentsForm } from "./widgets/appointments/appointments
 export { default as PatientBanner } from "./widgets/banner/patient-banner.component";
 
 export { default as ConditionsOverview } from "./widgets/conditions/conditions-overview.component";
-export { default as ConditionsSummary } from "./widgets/conditions/conditions.component";
+export { default as Conditions } from "./widgets/conditions/conditions.component";
 
 export { default as HeightAndWeightOverview } from "./widgets/heightandweight/heightandweight-overview.component";
 export { default as HeightAndWeightSummary } from "./widgets/heightandweight/heightandweight-summary.component";

--- a/src/widgets/conditions/condition-record.component.tsx
+++ b/src/widgets/conditions/condition-record.component.tsx
@@ -14,13 +14,11 @@ export default function ConditionRecord(props: ConditionRecordProps) {
 
   React.useEffect(() => {
     if (!isLoadingPatient && patient) {
-      const abortController = new AbortController();
-
-      getConditionByUuid(match.params["conditionUuid"], abortController)
-        .then(condition => setPatientCondition(condition))
-        .catch(createErrorHandler());
-
-      return () => abortController.abort();
+      const sub = getConditionByUuid(match.params["conditionUuid"]).subscribe(
+        condition => setPatientCondition(condition),
+        createErrorHandler()
+      );
+      return () => sub.unsubscribe();
     }
   }, [isLoadingPatient, patient, match.params]);
 

--- a/src/widgets/conditions/condition-record.test.tsx
+++ b/src/widgets/conditions/condition-record.test.tsx
@@ -8,6 +8,7 @@ import {
   patient,
   mockPatientConditionResult
 } from "../../../__mocks__/conditions.mock";
+import { of } from "rxjs";
 
 const mockPerformPatientConditionSearch = getConditionByUuid as jest.Mock;
 const mockUseCurrentPatient = useCurrentPatient as jest.Mock;
@@ -30,7 +31,7 @@ describe("<ConditionRecord />", () => {
   it("renders without dying", async () => {
     mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
     mockPerformPatientConditionSearch.mockReturnValue(
-      Promise.resolve(mockPatientConditionResult)
+      of(mockPatientConditionResult)
     );
     wrapper = render(
       <BrowserRouter>
@@ -46,7 +47,7 @@ describe("<ConditionRecord />", () => {
   it("displays a detailed summary of the selected condition", async () => {
     mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
     mockPerformPatientConditionSearch.mockReturnValue(
-      Promise.resolve(mockPatientConditionResult)
+      of(mockPatientConditionResult)
     );
     wrapper = render(
       <BrowserRouter>

--- a/src/widgets/conditions/conditions-detailed-summary.component.tsx
+++ b/src/widgets/conditions/conditions-detailed-summary.component.tsx
@@ -94,9 +94,6 @@ export default function ConditionsDetailedSummary(
                 })}
           </tbody>
         </table>
-        <div className={`omrs-type-body-regular ${styles.conditionFooter}`}>
-          <p>No more conditions available</p>
-        </div>
       </SummaryCard>
     );
   }

--- a/src/widgets/conditions/conditions-detailed-summary.css
+++ b/src/widgets/conditions/conditions-detailed-summary.css
@@ -97,12 +97,6 @@
   margin-right: 1rem;
 }
 
-.conditionFooter {
-  text-align: center;
-  font-family: "Work Sans";
-  color: var(--omrs-color-ink-medium-contrast);
-}
-
 .conditionMargin {
   margin: 1rem 1rem;
 }

--- a/src/widgets/conditions/conditions-overview.component.tsx
+++ b/src/widgets/conditions/conditions-overview.component.tsx
@@ -66,7 +66,7 @@ export default function ConditionsOverview(props: ConditionsOverviewProps) {
           return (
             <SummaryCardRow
               key={condition.resource.id}
-              linkTo={`${conditionsPath}/${condition.uuid}`}
+              linkTo={`${conditionsPath}/${condition.resource.id}`}
             >
               <HorizontalLabelValue
                 label={condition.resource.code.text}

--- a/src/widgets/conditions/conditions.component.tsx
+++ b/src/widgets/conditions/conditions.component.tsx
@@ -11,7 +11,7 @@ function Conditions(props) {
       <Route exact path={match.path}>
         <ConditionsDetailedSummary />
       </Route>
-      <Route exact path={`${match.path}/:programUuid`}>
+      <Route exact path={`${match.path}/:conditionUuid`}>
         <ConditionRecord />
       </Route>
     </Switch>

--- a/src/widgets/conditions/conditions.resource.tsx
+++ b/src/widgets/conditions/conditions.resource.tsx
@@ -8,11 +8,12 @@ export function performPatientConditionsSearch(
   return Promise.resolve(mockPatientConditionsSearchResponse);
 }
 
-export function getConditionByUuid(
-  conditionUuid: string,
-  abortController: AbortController
-) {
-  return Promise.resolve(mockPatientConditionSearchResponse);
+export function getConditionByUuid(conditionUuid: string) {
+  return of(
+    mockPatientConditionsSearchResponse.entry.find(
+      res => res.resource.id === conditionUuid
+    )
+  );
 }
 
 const mockPatientConditionSearchResponse = {


### PR DESCRIPTION
Fixes that should have been in #15 :

- Render the selected condition rather than rendering the same one regardless of which condition was selected.
- Change the condition link in ConditionsOverviewComponent to pick the `resource.id` from the selected condition - there is no `uuid` property.
- Change the glob in the `ConditionRecord` route path in the Conditions component to match `conditionUuid` instead of `programUuid`.
- Change `ConditionsSummary` export to `Conditions`
- Got rid of `No more conditions available` text in SummaryCard footer