### PR TITLE
Use formatDuration helper for past medications

### DIFF
--- a/src/widgets/medications/medications-detailed-summary.component.tsx
+++ b/src/widgets/medications/medications-detailed-summary.component.tsx
@@ -237,8 +237,7 @@ export default function MedicationsDetailedSummary(
                               {" "}
                               &mdash; {
                                 medication?.frequency?.display
-                              } &mdash; {medication?.duration}{" "}
-                              {(medication?.durationUnits?.display).toLowerCase()}
+                              } &mdash; {formatDuration(medication)}
                             </span>{" "}
                             <span
                               style={{


### PR DESCRIPTION
So you end up with appropriate formatting when the `duration` is 1 e.g. 1 Year, 1 Month, 1 Day or 1 Week.

<img width="634" alt="Screenshot 2020-03-25 at 10 53 58" src="https://user-images.githubusercontent.com/8509731/77514036-1dee0580-6e87-11ea-8d33-fe02b080d1f6.png">

<img width="625" alt="Screenshot 2020-03-25 at 10 54 24" src="https://user-images.githubusercontent.com/8509731/77514045-20505f80-6e87-11ea-8486-af83446b5385.png">
