### PR TITLE
MF-153: Medication Orders Overview showing inactive medications

### DIFF
--- a/src/widgets/medications/medication-order-basket.component.tsx
+++ b/src/widgets/medications/medication-order-basket.component.tsx
@@ -149,7 +149,7 @@ export default function MedicationOrderBasket(
   };
 
   function navigate() {
-    history.push(`/patient/${patientUuid}/chart/medications`);
+    history.push(`/patient/${patientUuid}/chart/orders/medication-orders`);
   }
 
   const handleRemoveOrderItem = (indexNum: any) => {

--- a/src/widgets/medications/medications-detailed-summary.component.tsx
+++ b/src/widgets/medications/medications-detailed-summary.component.tsx
@@ -32,18 +32,23 @@ export default function MedicationsDetailedSummary(
   const match = useRouteMatch();
 
   React.useEffect(() => {
-    const sub = fetchPatientMedications(patientUuid).subscribe(medications => {
-      const currentMeds = [];
-      const pastMeds = [];
-      medications.map((med: any) =>
-        med.action === "NEW" ? currentMeds.push(med) : pastMeds.push(med)
-      );
+    if (patientUuid) {
+      const sub = fetchPatientMedications(patientUuid).subscribe(
+        medications => {
+          const currentMeds = [];
+          const pastMeds = [];
+          medications.map((med: any) =>
+            med.action === "NEW" ? currentMeds.push(med) : pastMeds.push(med)
+          );
 
-      setPatientMedications(medications);
-      setCurrentMedications(currentMeds);
-      setPastMedications(pastMeds);
-    }, createErrorHandler());
-    return () => sub.unsubscribe();
+          setPatientMedications(medications);
+          setCurrentMedications(currentMeds);
+          setPastMedications(pastMeds);
+        },
+        createErrorHandler()
+      );
+      return () => sub.unsubscribe();
+    }
   }, [patientUuid]);
 
   function displayCurrentMedications() {

--- a/src/widgets/medications/medications-overview.component.tsx
+++ b/src/widgets/medications/medications-overview.component.tsx
@@ -36,7 +36,14 @@ export default function MedicationsOverview(props: MedicationsOverviewProps) {
   React.useEffect(() => {
     if (patientUuid) {
       const subscription = fetchPatientMedications(patientUuid).subscribe(
-        Medications => setPatientMedications(Medications),
+        medications => {
+          const inactiveStates = ["REVISE", "DISCONTINUE"];
+          setPatientMedications(
+            medications.filter(
+              (med: any) => !inactiveStates.includes(med.action)
+            )
+          );
+        },
         createErrorHandler()
       );
       return () => subscription.unsubscribe();


### PR DESCRIPTION
Fixes issue where inactive/discontinued medications were being displayed on the medication orders overview  https://issues.openmrs.org/browse/MF-153.

Also: added patientUuid check to the medication orders request being made by MedicationsDetailedSummary. Having this check there means that the request will be made only when a patientUuid is available.