### PR TITLE
MF-158: Infer enrollment location from session

### DIFF
--- a/__mocks__/session.mock.ts
+++ b/__mocks__/session.mock.ts
@@ -1,0 +1,107 @@
+export const mockSessionDataResponse = {
+  data: {
+    authenticated: true,
+    locale: "en_GB",
+    currentProvider: {
+      uuid: "",
+      display: "Test User",
+      person: {
+        uuid: "ddd5fa89-48a6-432e-abb8-0d11b4be7e4f",
+        display: "Test User"
+      },
+      identifier: "UNKNOWN",
+      attributes: []
+    },
+    sessionLocation: {
+      uuid: "b1a8b05e-3542-4037-bbd3-998ee9c40574",
+      display: "Inpatient Ward",
+      name: "Inpatient Ward",
+      description: null,
+      address1: null,
+      address2: null,
+      cityVillage: null,
+      stateProvince: null,
+      country: null,
+      postalCode: null,
+      latitude: null,
+      longitude: null,
+      countyDistrict: null,
+      address3: null,
+      address4: null,
+      address5: null,
+      address6: null,
+      tags: [
+        {
+          uuid: "8d4626ca-7abd-42ad-be48-56767bbcf272",
+          display: "Transfer Location"
+        },
+        {
+          uuid: "b8bbf83e-645f-451f-8efe-a0db56f09676",
+          display: "Login Location"
+        },
+        {
+          uuid: "1c783dca-fd54-4ea8-a0fc-2875374e9cb6",
+          display: "Admission Location"
+        }
+      ],
+      parentLocation: {
+        uuid: "aff27d58-a15c-49a6-9beb-d30dcfc0c66e",
+        display: "Amani Hospital"
+      },
+      childLocations: [],
+      retired: false,
+      attributes: [],
+      address7: null,
+      address8: null,
+      address9: null,
+      address10: null,
+      address11: null,
+      address12: null,
+      address13: null,
+      address14: null,
+      address15: null
+    },
+    user: {
+      uuid: "45ce6c2e-dd5a-11e6-9d9c-0242ac150002",
+      display: "admin",
+      username: "",
+      systemId: "admin",
+      userProperties: {
+        loginAttempts: "0"
+      },
+      person: {
+        uuid: "0775e6b7-f439-40e5-87a3-2bd11f3b9ee5",
+        display: "Test User"
+      },
+      privileges: [
+        {
+          uuid: "62431c71-5244-11ea-a771-0242ac160002",
+          display: "Manage Appointment Services"
+        },
+        {
+          uuid: "6206682c-5244-11ea-a771-0242ac160002",
+          display: "Manage Appointments"
+        },
+        {
+          uuid: "6280ff58-5244-11ea-a771-0242ac160002",
+          display: "Manage Appointment Specialities"
+        }
+      ],
+      roles: [
+        {
+          uuid: "8d94f852-c2cc-11de-8d13-0010c6dffd0f",
+          display: "System Developer"
+        },
+        {
+          uuid: "62c195c5-5244-11ea-a771-0242ac160002",
+          display: "Bahmni Role"
+        },
+        {
+          uuid: "8d94f280-c2cc-11de-8d13-0010c6dffd0f",
+          display: "Provider"
+        }
+      ],
+      retired: false
+    }
+  }
+};

--- a/src/widgets/programs/programs-form.component.tsx
+++ b/src/widgets/programs/programs-form.component.tsx
@@ -7,6 +7,7 @@ import {
   fetchEnrolledPrograms,
   fetchLocations,
   getPatientProgramByUuid,
+  getSession,
   updateProgramEnrollment
 } from "./programs.resource";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
@@ -24,6 +25,7 @@ export default function ProgramsForm(props: ProgramsFormProps) {
   const [allPrograms, setAllPrograms] = useState(null);
   const [eligiblePrograms, setEligiblePrograms] = useState(null);
   const [enrolledPrograms, setEnrolledPrograms] = useState(null);
+  const [sessionLocation, setSessionLocation] = useState("");
   const [location, setLocation] = useState("");
   const [program, setProgram] = useState("");
   const [enrollmentDate, setEnrollmentDate] = useState(
@@ -39,6 +41,17 @@ export default function ProgramsForm(props: ProgramsFormProps) {
     patientErr
   ] = useCurrentPatient();
   const history = useHistory();
+
+  useEffect(() => {
+    if (patientUuid) {
+      const abortController = new AbortController();
+      getSession(abortController).then(({ data }) => {
+        if (data.sessionLocation.uuid) {
+          setSessionLocation(data.sessionLocation.uuid);
+        }
+      });
+    }
+  }, [patientUuid]);
 
   useEffect(() => {
     if (patientUuid) {
@@ -245,7 +258,7 @@ export default function ProgramsForm(props: ProgramsFormProps) {
                 <select
                   id="location"
                   name="locations"
-                  value={location}
+                  value={sessionLocation ? sessionLocation : location}
                   onChange={evt => setLocation(evt.target.value)}
                 >
                   <option>Choose a location:</option>

--- a/src/widgets/programs/programs-form.test.tsx
+++ b/src/widgets/programs/programs-form.test.tsx
@@ -5,7 +5,8 @@ import {
   fetchPrograms,
   fetchEnrolledPrograms,
   fetchLocations,
-  getPatientProgramByUuid
+  getPatientProgramByUuid,
+  getSession
 } from "./programs.resource";
 import ProgramsForm from "./programs-form.component";
 import { mockPatient } from "../../../__mocks__/patient.mock";
@@ -15,6 +16,7 @@ import {
   mockLocationsResponse,
   mockOncProgramResponse
 } from "../../../__mocks__/programs.mock";
+import { mockSessionDataResponse } from "../../../__mocks__/session.mock";
 import { BrowserRouter } from "react-router-dom";
 import { of } from "rxjs/internal/observable/of";
 
@@ -23,12 +25,14 @@ const mockFetchLocations = fetchLocations as jest.Mock;
 const mockFetchCarePrograms = fetchPrograms as jest.Mock;
 const mockFetchEnrolledPrograms = fetchEnrolledPrograms as jest.Mock;
 const mockGetProgramByUuid = getPatientProgramByUuid as jest.Mock;
+const mockGetSession = getSession as jest.Mock;
 
 jest.mock("./programs.resource", () => ({
   fetchEnrolledPrograms: jest.fn(),
   fetchPrograms: jest.fn(),
   fetchLocations: jest.fn(),
   getPatientProgramByUuid: jest.fn(),
+  getSession: jest.fn(),
   saveProgramEnrollment: jest.fn()
 }));
 
@@ -47,6 +51,7 @@ describe("<ProgramsForm />", () => {
       mockPatient.id,
       null
     ]);
+    mockGetSession.mockReturnValue(Promise.resolve(mockSessionDataResponse));
     mockFetchCarePrograms.mockReturnValue(of(mockCareProgramsResponse));
     mockFetchLocations.mockReturnValue(of(mockLocationsResponse));
     mockGetProgramByUuid.mockReturnValue(of(mockOncProgramResponse));

--- a/src/widgets/programs/programs.resource.tsx
+++ b/src/widgets/programs/programs.resource.tsx
@@ -67,6 +67,12 @@ export function fetchLocations(): Observable<any> {
   ).pipe(map(({ data }) => data["results"]));
 }
 
+export function getSession(abortController: AbortController) {
+  return openmrsFetch(`/ws/rest/v1/appui/session`, {
+    signal: abortController.signal
+  });
+}
+
 type PatientProgram = {
   uuid: String;
   program: {};


### PR DESCRIPTION
Infer the logged-in user's location from the session and pre-select that as the value of the enrollment location field when enrolling a patient into a program https://issues.openmrs.org/browse/MF-158

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8509731/78033489-25257f80-736f-11ea-81ed-378c7a6efa1b.gif)

