### PR TITLE
MF-160: Change text from "Medication History" to Medication Orders

### DIFF
--- a/src/widgets/medications/medications-detailed-summary.component.tsx
+++ b/src/widgets/medications/medications-detailed-summary.component.tsx
@@ -344,7 +344,7 @@ export default function MedicationsDetailedSummary(
             <SummaryCard name="Medications" styles={{ width: "100%" }}>
               <div className={styles.emptyMedications}>
                 <p className="omrs-bold">
-                  The patient's medication history is not documented.
+                  This patient has no medication orders in the system.
                 </p>
                 <p className="omrs-bold">
                   <button
@@ -356,7 +356,7 @@ export default function MedicationsDetailedSummary(
                       )
                     }
                   >
-                    Add medication history
+                    Add medication order
                   </button>
                 </p>
               </div>

--- a/src/widgets/medications/medications-detailed-summary.test.tsx
+++ b/src/widgets/medications/medications-detailed-summary.test.tsx
@@ -105,11 +105,12 @@ describe("<MedicationsDetailedSummary/>", () => {
       expect(wrapper).toBeDefined();
       expect(wrapper.getByText("Medications").textContent).toBeTruthy();
       expect(
-        wrapper.getByText("The patient's medication history is not documented.")
-          .textContent
+        wrapper.getByText(
+          "This patient has no medication orders in the system."
+        ).textContent
       ).toBeTruthy();
       expect(
-        wrapper.getByText("Add medication history").textContent
+        wrapper.getByText("Add medication order").textContent
       ).toBeTruthy();
     });
   });


### PR DESCRIPTION
As reported in https://issues.openmrs.org/browse/MF-161

<img width="1792" alt="Screenshot 2020-04-01 at 21 50 11" src="https://user-images.githubusercontent.com/8509731/78175237-3a7bd600-7463-11ea-9dce-789541ea030d.png">
