### PR TITLE
MF-168: Fix unique key prop error for vitals resource

### DIFF
--- a/__mocks__/vitals.mock.ts
+++ b/__mocks__/vitals.mock.ts
@@ -73,7 +73,7 @@ export const mockVitalsResponse = {
             identifier: { id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518" },
             display: "John Taylor(Identifier:10010W)"
           },
-          context: {
+          encounter: {
             reference: "Encounter/c8876e57-f788-47a1-b8fd-30dbbb497941"
           },
           effectiveDateTime: "2016-05-16T06:13:36+00:00",
@@ -146,7 +146,7 @@ export const mockVitalsResponse = {
             identifier: { id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518" },
             display: "John Taylor(Identifier:10010W)"
           },
-          context: {
+          encounter: {
             reference: "Encounter/1d2bdaf3-2a70-4035-844b-bbbb42cb666e"
           },
           effectiveDateTime: "2015-08-25T06:30:35+00:00",
@@ -223,7 +223,7 @@ export const mockVitalsResponse = {
             identifier: { id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518" },
             display: "John Taylor(Identifier:10010W)"
           },
-          context: {
+          encounter: {
             reference: "Encounter/c8876e57-f788-47a1-b8fd-30dbbb497941"
           },
           effectiveDateTime: "2016-05-16T06:13:36+00:00",
@@ -300,7 +300,7 @@ export const mockVitalsResponse = {
             identifier: { id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518" },
             display: "John Taylor(Identifier:10010W)"
           },
-          context: {
+          encounter: {
             reference: "Encounter/1d2bdaf3-2a70-4035-844b-bbbb42cb666e"
           },
           effectiveDateTime: "2015-08-25T06:30:35+00:00",
@@ -373,7 +373,7 @@ export const mockVitalsResponse = {
             identifier: { id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518" },
             display: "John Taylor(Identifier:10010W)"
           },
-          context: {
+          encounter: {
             reference: "Encounter/c8876e57-f788-47a1-b8fd-30dbbb497941"
           },
           effectiveDateTime: "2016-05-16T06:13:36+00:00",
@@ -446,7 +446,7 @@ export const mockVitalsResponse = {
             identifier: { id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518" },
             display: "John Taylor(Identifier:10010W)"
           },
-          context: {
+          encounter: {
             reference: "Encounter/1d2bdaf3-2a70-4035-844b-bbbb42cb666e"
           },
           effectiveDateTime: "2015-08-25T06:30:35+00:00",
@@ -525,7 +525,7 @@ export const mockVitalsResponse = {
             identifier: { id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518" },
             display: "John Taylor(Identifier:10010W)"
           },
-          context: {
+          encounter: {
             reference: "Encounter/c8876e57-f788-47a1-b8fd-30dbbb497941"
           },
           effectiveDateTime: "2016-05-16T06:13:36+00:00",
@@ -604,7 +604,7 @@ export const mockVitalsResponse = {
             identifier: { id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518" },
             display: "John Taylor(Identifier:10010W)"
           },
-          context: {
+          encounter: {
             reference: "Encounter/1d2bdaf3-2a70-4035-844b-bbbb42cb666e"
           },
           effectiveDateTime: "2015-08-25T06:30:35+00:00",
@@ -678,7 +678,7 @@ export const mockVitalsResponse = {
             identifier: { id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518" },
             display: "John Taylor(Identifier:10010W)"
           },
-          context: {
+          encounter: {
             reference: "Encounter/c8876e57-f788-47a1-b8fd-30dbbb497941"
           },
           effectiveDateTime: "2016-05-16T06:13:36+00:00",
@@ -752,7 +752,7 @@ export const mockVitalsResponse = {
             identifier: { id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518" },
             display: "John Taylor(Identifier:10010W)"
           },
-          context: {
+          encounter: {
             reference: "Encounter/1d2bdaf3-2a70-4035-844b-bbbb42cb666e"
           },
           effectiveDateTime: "2015-08-25T06:30:35+00:00",

--- a/src/widgets/vitals/vital-record.component.tsx
+++ b/src/widgets/vitals/vital-record.component.tsx
@@ -13,7 +13,7 @@ export default function VitalRecord(props: VitalRecordProps) {
   const match = useRouteMatch();
 
   useEffect(() => {
-    if (!isLoadingPatient && patient && match.params) {
+    if (!isLoadingPatient && patientUuid && match.params) {
       const sub = performPatientsVitalsSearch(patientUuid).subscribe(
         vitals =>
           setVitalSigns(
@@ -23,7 +23,7 @@ export default function VitalRecord(props: VitalRecordProps) {
       );
       return () => sub.unsubscribe();
     }
-  }, [isLoadingPatient, patient, match.params]);
+  }, [isLoadingPatient, patientUuid, match.params]);
 
   return (
     <>

--- a/src/widgets/vitals/vitals-card.resource.tsx
+++ b/src/widgets/vitals/vitals-card.resource.tsx
@@ -3,8 +3,8 @@ import {
   openmrsFetch,
   fhirConfig
 } from "@openmrs/esm-api";
-import { Observable, of } from "rxjs";
-import { map, take, single } from "rxjs/operators";
+import { Observable } from "rxjs";
+import { map, take } from "rxjs/operators";
 import { Vitals } from "./vitals-form.component";
 
 const SYSTOLIC_BLOOD_PRESSURE_CONCEPT: string =
@@ -91,7 +91,7 @@ function formatVitals(
     );
 
     return (patientVitals = {
-      id: systolic && systolic?.context?.reference.replace("Encounter/", ""),
+      id: systolic && systolic?.encounter?.reference.replace("Encounter/", ""),
       date: systolic && systolic.issued,
       systolic: systolic && systolic.valueQuantity.value,
       diastolic: diastolic && diastolic.valueQuantity.value,


### PR DESCRIPTION
<img width="709" alt="Screenshot 2020-04-16 at 13 03 54" src="https://user-images.githubusercontent.com/8509731/79449192-767a7380-7feb-11ea-8d4e-a27c0def2837.png">

All the vitals had an id `undefined` as the property with the encounter id in FHIR is called `encounter`, not `context`.

<img width="308" alt="Screenshot 2020-04-16 at 13 03 30" src="https://user-images.githubusercontent.com/8509731/79449224-84c88f80-7feb-11ea-84c2-5b75083de081.png">

Steps to recreate:

- Load up patient search and search for 'John Wilson' or any other patient with recorded vitals.
- The error should pop up in the console.