### PR TITLE
MF-184: Make newWorkspaceItem reusable across widgets

### DIFF
--- a/src/widgets/shared-utils.tsx
+++ b/src/widgets/shared-utils.tsx
@@ -1,0 +1,14 @@
+import { newWorkspaceItem } from "@openmrs/esm-api";
+
+export const openWorkspaceTab = (componentToAdd, componentName, params?) => {
+  newWorkspaceItem({
+    component: componentToAdd,
+    name: componentName,
+    props: {
+      match: { params: params ? params : {} }
+    },
+    inProgress: false,
+    validations: (workspaceTabs: Array<{ component: React.FC }>) =>
+      workspaceTabs.findIndex(tab => tab.component === componentToAdd)
+  });
+};


### PR DESCRIPTION
Presently, most widgets are redeclaring the logic for launching new workspaces. It would be worthwhile to DRY it up by making that bit of logic reusable.