### PR TITLE
MF-184-appointments: Make newWorkspaceItem reusable across appointments widget

### DIFF
--- a/src/widgets/allergies/allergies-detailed-summary.component.tsx
+++ b/src/widgets/allergies/allergies-detailed-summary.component.tsx
@@ -1,15 +1,13 @@
 import React from "react";
 import { Link, useRouteMatch } from "react-router-dom";
-import {
-  performPatientAllergySearch,
-  openAllergyFormWorkspaceItem
-} from "./allergy-intolerance.resource";
+import { performPatientAllergySearch } from "./allergy-intolerance.resource";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import styles from "./allergies-detailed-summary.css";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import dayjs from "dayjs";
-import { useCurrentPatient, newWorkspaceItem } from "@openmrs/esm-api";
+import { useCurrentPatient } from "@openmrs/esm-api";
 import AllergyForm from "./allergy-form.component";
+import { openWorkspaceTab } from "../shared-utils";
 
 export default function AllergiesDetailedSummary(
   props: AllergiesDetailedSummaryProps
@@ -42,7 +40,7 @@ export default function AllergiesDetailedSummary(
         styles={{ width: "100%" }}
         addComponent={AllergyForm}
         showComponent={() =>
-          openAllergyFormWorkspaceItem(AllergyForm, "Allergy Form", {
+          openWorkspaceTab(AllergyForm, "Allergy Form", {
             allergyUuid: null
           })
         }
@@ -173,7 +171,7 @@ export default function AllergiesDetailedSummary(
         styles={{ width: "100%" }}
         addComponent={AllergyForm}
         showComponent={() =>
-          openAllergyFormWorkspaceItem(AllergyForm, "Allergy Form", {
+          openWorkspaceTab(AllergyForm, "Allergy Form", {
             allergyUuid: null
           })
         }
@@ -188,7 +186,7 @@ export default function AllergiesDetailedSummary(
               className="omrs-btn omrs-outlined-action"
               type="button"
               onClick={() =>
-                openAllergyFormWorkspaceItem(AllergyForm, "Allergy Form", {
+                openWorkspaceTab(AllergyForm, "Allergy Form", {
                   allergyUuid: null
                 })
               }

--- a/src/widgets/allergies/allergies-detailed-summary.test.tsx
+++ b/src/widgets/allergies/allergies-detailed-summary.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { performPatientAllergySearch } from "./allergy-intolerance.resource";
 import { render, cleanup, wait } from "@testing-library/react";
 import { BrowserRouter, match } from "react-router-dom";
-import AllergyOverviewLevelTwo from "./allergies-detailed-summary.component";
+import AllergiesOverviewLevelTwo from "./allergies-detailed-summary.component";
 import { useCurrentPatient } from "../../../__mocks__/openmrs-esm-api.mock";
 import { fhirConfig } from "@openmrs/esm-api";
 const mockPerformPatientAllergySearch = performPatientAllergySearch as jest.Mock;
@@ -291,7 +291,7 @@ describe("AlleryCardLevelTwo />", () => {
     );
     wrapper = render(
       <BrowserRouter>
-        <AllergyOverviewLevelTwo />
+        <AllergiesOverviewLevelTwo />
       </BrowserRouter>
     );
 
@@ -307,7 +307,7 @@ describe("AlleryCardLevelTwo />", () => {
     );
     wrapper = render(
       <BrowserRouter>
-        <AllergyOverviewLevelTwo />
+        <AllergiesOverviewLevelTwo />
       </BrowserRouter>
     );
 
@@ -324,7 +324,7 @@ describe("AlleryCardLevelTwo />", () => {
     );
     wrapper = render(
       <BrowserRouter>
-        <AllergyOverviewLevelTwo />
+        <AllergiesOverviewLevelTwo />
       </BrowserRouter>
     );
 

--- a/src/widgets/allergies/allergies-overview.component.tsx
+++ b/src/widgets/allergies/allergies-overview.component.tsx
@@ -7,8 +7,10 @@ import HorizontalLabelValue from "../../ui-components/cards/horizontal-label-val
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import { useRouteMatch } from "react-router-dom";
+import AllergyForm from "./allergy-form.component";
+import { openWorkspaceTab } from "../shared-utils";
 
-export default function AllergyOverview(props: AllergyOverviewProps) {
+export default function AllergiesOverview(props: AllergiesOverviewProps) {
   const [patientAllergy, setPatientAllergy] = React.useState(null);
   const [
     isLoadingPatient,
@@ -39,6 +41,12 @@ export default function AllergyOverview(props: AllergyOverviewProps) {
       name="Allergies"
       styles={{ margin: "1.25rem, 1.5rem" }}
       link={`/patient/${patientUuid}/chart/allergies`}
+      addComponent={AllergyForm}
+      showComponent={() => {
+        openWorkspaceTab(AllergyForm, "Allergy Form", {
+          allergyUuid: null
+        });
+      }}
     >
       {patientAllergy &&
         patientAllergy.total > 0 &&
@@ -69,4 +77,4 @@ export default function AllergyOverview(props: AllergyOverviewProps) {
   );
 }
 
-type AllergyOverviewProps = { basePath: string };
+type AllergiesOverviewProps = { basePath: string };

--- a/src/widgets/allergies/allergies-overview.test.tsx
+++ b/src/widgets/allergies/allergies-overview.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, cleanup, wait } from "@testing-library/react";
-import AllergyOverview from "./allergies-overview.component";
+import AllergiesOverview from "./allergies-overview.component";
 import { BrowserRouter } from "react-router-dom";
 import { performPatientAllergySearch } from "./allergy-intolerance.resource";
 import { act } from "react-dom/test-utils";
@@ -162,7 +162,7 @@ const patient: fhir.Patient = {
   ]
 };
 
-describe("<AllergyOverview/>", () => {
+describe("<AllergiesOverview/>", () => {
   let match, wrapper: any;
 
   afterEach(cleanup);
@@ -174,14 +174,14 @@ describe("<AllergyOverview/>", () => {
   beforeEach(mockPerformPatientAllergySearch.mockReset);
   beforeEach(mockUseCurrentPatient.mockReset);
 
-  it("render AllergyOverview without dying", async () => {
+  it("render AllergiesOverview without dying", async () => {
     mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
     mockPerformPatientAllergySearch.mockReturnValue(
       Promise.resolve(mockPatientAllergyResult)
     );
     wrapper = render(
       <BrowserRouter>
-        <AllergyOverview basePath="/" />
+        <AllergiesOverview basePath="/" />
       </BrowserRouter>
     );
 
@@ -197,7 +197,7 @@ describe("<AllergyOverview/>", () => {
     );
     wrapper = render(
       <BrowserRouter>
-        <AllergyOverview basePath="/" />
+        <AllergiesOverview basePath="/" />
       </BrowserRouter>
     );
     await wait(() => {

--- a/src/widgets/allergies/allergy-intolerance.resource.tsx
+++ b/src/widgets/allergies/allergy-intolerance.resource.tsx
@@ -1,7 +1,6 @@
 import {
   openmrsFetch,
   openmrsObservableFetch,
-  newWorkspaceItem,
   fhirConfig
 } from "@openmrs/esm-api";
 import { Observable } from "rxjs";
@@ -133,20 +132,3 @@ export function deletePatientAllergy(
     }
   );
 }
-
-export const openAllergyFormWorkspaceItem = (
-  componentToAdd,
-  componentName,
-  paramsValue?
-) => {
-  newWorkspaceItem({
-    component: componentToAdd,
-    name: componentName,
-    props: {
-      match: { params: paramsValue }
-    },
-    inProgress: false,
-    validations: (workspaceTabs: any[]) =>
-      workspaceTabs.findIndex(tab => tab.component === componentToAdd)
-  });
-};

--- a/src/widgets/allergies/allergy-record.component.tsx
+++ b/src/widgets/allergies/allergy-record.component.tsx
@@ -1,15 +1,13 @@
 import React from "react";
 import { useRouteMatch } from "react-router-dom";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
-import {
-  getPatientAllergyByPatientUuid,
-  openAllergyFormWorkspaceItem
-} from "./allergy-intolerance.resource";
+import { getPatientAllergyByPatientUuid } from "./allergy-intolerance.resource";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import styles from "./allergy-record.css";
 import dayjs from "dayjs";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import AllergyForm from "./allergy-form.component";
+import { openWorkspaceTab } from "../shared-utils";
 
 export default function AllergyRecord(props: AllergyRecordProps) {
   const [allergy, setAllergy] = React.useState(null);
@@ -40,7 +38,7 @@ export default function AllergyRecord(props: AllergyRecordProps) {
         styles={{ width: "100%" }}
         editComponent={AllergyForm}
         showComponent={() =>
-          openAllergyFormWorkspaceItem(AllergyForm, "Edit Allergy", {
+          openWorkspaceTab(AllergyForm, "Edit Allergy", {
             allergyUuid: allergy.uuid
           })
         }

--- a/src/widgets/appointments/appointment-record.component.tsx
+++ b/src/widgets/appointments/appointment-record.component.tsx
@@ -1,18 +1,14 @@
 import React, { useState, useEffect } from "react";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import AppointmentsForm from "./appointments-form.component";
-import { openMedicationWorkspaceTab } from "../medications/medication-orders-utils";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import dayjs from "dayjs";
-import {
-  getAppointments,
-  getAppointmentsByUuid
-} from "./appointments.resource";
+import { getAppointmentsByUuid } from "./appointments.resource";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
-import { isEmpty } from "lodash-es";
 import { useRouteMatch } from "react-router-dom";
 import VerticalLabelValue from "../../ui-components/cards/vertical-label-value.component";
 import styles from "./appointment-record.css";
+import { openWorkspaceTab } from "../shared-utils";
 
 export default function AppointmentRecord(props: AppointmentRecordProps) {
   const [patientAppointment, setPatientAppointment] = useState(null);
@@ -43,7 +39,7 @@ export default function AppointmentRecord(props: AppointmentRecordProps) {
         name="Appointment"
         addComponent={AppointmentsForm}
         showComponent={() =>
-          openMedicationWorkspaceTab(AppointmentsForm, "Appointment Form")
+          openWorkspaceTab(AppointmentsForm, "Appointment Form")
         }
       >
         {patientAppointment && (

--- a/src/widgets/appointments/appointment-record.test.tsx
+++ b/src/widgets/appointments/appointment-record.test.tsx
@@ -15,8 +15,6 @@ import {
   mockAppointmentResponse
 } from "../../../__mocks__/appointment.mock";
 import { mockPatient } from "../../../__mocks__/patient.mock";
-import * as appointmentResource from "./appointments.resource";
-import { act } from "react-dom/test-utils";
 import {
   getAppointments,
   getAppointmentsByUuid
@@ -24,12 +22,10 @@ import {
 
 const mockUseCurrentPatient = useCurrentPatient as jest.Mock;
 const mockUseRouteMatch = useRouteMatch as jest.Mock;
-const mockgetAppointments = getAppointments as jest.Mock;
 const mockGetAppointmentsByUuid = getAppointmentsByUuid as jest.Mock;
 
 jest.mock("@openmrs/esm-api", () => ({
-  useCurrentPatient: jest.fn(),
-  newWorkspaceItem: jest.fn()
+  useCurrentPatient: jest.fn()
 }));
 
 jest.mock("react-router", () => ({
@@ -39,11 +35,10 @@ jest.mock("react-router", () => ({
 
 jest.mock("./appointments.resource", () => ({
   getAppointments: jest.fn(),
-  getAppointmentsByUuid: jest.fn(),
-  openAppointmentWorkspaceItem: jest.fn().mockImplementation(() => jest.fn())
+  getAppointmentsByUuid: jest.fn()
 }));
 
-describe("<AppointementRecord/>", () => {
+describe("<AppointmentRecord />", () => {
   let match: match;
   let wrapper: RenderResult;
   let patient: fhir.Patient = mockPatient;
@@ -81,7 +76,7 @@ describe("<AppointementRecord/>", () => {
     });
   });
 
-  it("should display patient appointment correctly", async () => {
+  it("should display the patient's appointments correctly", async () => {
     mockUseRouteMatch.mockReturnValue(match);
     mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
     mockGetAppointmentsByUuid.mockReturnValue(
@@ -101,36 +96,6 @@ describe("<AppointementRecord/>", () => {
       expect(wrapper.getByText("WalkIn")).toBeTruthy();
       expect(wrapper.getByText("Scheduled")).toBeTruthy();
       expect(wrapper.getByText("23-Mar-2020")).toBeTruthy();
-    });
-  });
-
-  it("should open appointment form workspace", async () => {
-    mockUseRouteMatch.mockReturnValue(match);
-    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
-    mockGetAppointmentsByUuid.mockReturnValue(
-      Promise.resolve(mockAppointmentResponse)
-    );
-
-    const networkItemSpy = jest.spyOn(
-      appointmentResource,
-      "openAppointmentWorkspaceItem"
-    );
-    networkItemSpy.mockImplementation(() => jest.fn());
-
-    wrapper = render(
-      <BrowserRouter>
-        <AppointmentRecord />
-      </BrowserRouter>
-    );
-
-    await wait(() => {
-      const addButton = wrapper.getByText("Add");
-
-      act(() => {
-        fireEvent.click(addButton);
-      });
-
-      expect(getAppointmentsByUuid).toHaveBeenCalled();
     });
   });
 });

--- a/src/widgets/appointments/appointments-detailed-summary.component.tsx
+++ b/src/widgets/appointments/appointments-detailed-summary.component.tsx
@@ -1,16 +1,14 @@
 import React, { useState, useEffect } from "react";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import dayjs from "dayjs";
-import {
-  getAppointments,
-  openAppointmentWorkspaceItem
-} from "./appointments.resource";
+import { getAppointments } from "./appointments.resource";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { SummaryCard } from "../../openmrs-esm-patient-chart-widgets";
 import styles from "./appointments-detailed-summary.css";
 import { Link, useRouteMatch } from "react-router-dom";
 import AppointmentsForm from "./appointments-form.component";
 import { isEmpty } from "lodash-es";
+import { openWorkspaceTab } from "../shared-utils";
 
 export default function AppointmentsDetailedSummary(
   props: AppointmentsDetailedSummaryProps
@@ -94,7 +92,7 @@ export default function AppointmentsDetailedSummary(
           styles={{ width: "100%" }}
           addComponent={AppointmentsForm}
           showComponent={() =>
-            openAppointmentWorkspaceItem(AppointmentsForm, "Appointment Form")
+            openWorkspaceTab(AppointmentsForm, "Appointment Form")
           }
         >
           <div className={styles.allergyMargin}>
@@ -107,10 +105,7 @@ export default function AppointmentsDetailedSummary(
                 className="omrs-btn omrs-outlined-action"
                 type="button"
                 onClick={() =>
-                  openAppointmentWorkspaceItem(
-                    AppointmentsForm,
-                    "Appointment Form"
-                  )
+                  openWorkspaceTab(AppointmentsForm, "Appointment Form")
                 }
               >
                 Add patient appointment

--- a/src/widgets/appointments/appointments.resource.tsx
+++ b/src/widgets/appointments/appointments.resource.tsx
@@ -1,4 +1,4 @@
-import { openmrsFetch, newWorkspaceItem } from "@openmrs/esm-api";
+import { openmrsFetch } from "@openmrs/esm-api";
 import { Appointment } from "./appointments-form.component";
 
 export function createAppointment(
@@ -62,22 +62,3 @@ export function getSession(abortController: AbortController) {
     signal: abortController.signal
   });
 }
-
-export const openAppointmentWorkspaceItem = (componentName, title) => {
-  newWorkspaceItem({
-    component: componentName,
-    name: title,
-    props: {
-      match: {
-        params: {
-          orderUuid: null,
-          drugName: null,
-          action: "NEW"
-        }
-      }
-    },
-    inProgress: false,
-    validations: (workspaceTabs: any[]) =>
-      workspaceTabs.findIndex(tab => tab.component === componentName)
-  });
-};

--- a/src/widgets/notes/notes-detailed-summary.component.tsx
+++ b/src/widgets/notes/notes-detailed-summary.component.tsx
@@ -11,7 +11,6 @@ import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { formatDate } from "../heightandweight/heightandweight-helper";
 import { useTranslation } from "react-i18next";
 import VisitNotes from "./visit-note.component";
-import { openAppointmentWorkspaceItem } from "../appointments/appointments.resource";
 import { isEmpty } from "lodash-es";
 
 function NotesDetailedSummary(props: NotesDetailedSummaryProps) {

--- a/src/widgets/shared-utils.tsx
+++ b/src/widgets/shared-utils.tsx
@@ -1,0 +1,14 @@
+import { newWorkspaceItem } from "@openmrs/esm-api";
+
+export const openWorkspaceTab = (componentToAdd, componentName, params?) => {
+  newWorkspaceItem({
+    component: componentToAdd,
+    name: componentName,
+    props: {
+      match: { params: params ? params : {} }
+    },
+    inProgress: false,
+    validations: (workspaceTabs: Array<{ component: React.FC }>) =>
+      workspaceTabs.findIndex(tab => tab.component === componentToAdd)
+  });
+};


### PR DESCRIPTION
Make newWorkspaceItem reusable across the components that make up the appointments widget.