### PR TITLE
MF-184-wrapup: Properly type shared utils

### DIFF
--- a/src/widgets/allergies/allergy-form.component.tsx
+++ b/src/widgets/allergies/allergy-form.component.tsx
@@ -13,7 +13,7 @@ import {
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import dayjs from "dayjs";
-//import { DataCaptureComponentProps } from "../../utils/data-capture-props";
+import { DataCaptureComponentProps } from "../shared-utils";
 
 const DRUG_ALLERGEN_CONCEPT: string = "162552AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 const ENVIROMENTAL_ALLERGEN_CONCEPT: string =
@@ -694,11 +694,4 @@ type Allergy = {
   severityUuid: string;
   comment: string;
   reactionsUuid: any[];
-};
-
-export type DataCaptureComponentProps = {
-  entryStarted: Function;
-  entrySubmitted: Function;
-  entryCancelled: Function;
-  closeComponent: Function;
 };

--- a/src/widgets/conditions/conditions-form.component.tsx
+++ b/src/widgets/conditions/conditions-form.component.tsx
@@ -6,6 +6,7 @@ import { useRouteMatch } from "react-router-dom";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import styles from "./conditions-form.css";
 import dayjs from "dayjs";
+import { DataCaptureComponentProps } from "../shared-utils";
 
 export function ConditionsForm(props: ConditionsFormProps) {
   const [conditionName, setConditionName] = useState("");
@@ -429,11 +430,4 @@ type Condition = {
   conditionName: string;
   clinicalStatus: string;
   onsetDate: string;
-};
-
-type DataCaptureComponentProps = {
-  entryStarted: () => {};
-  entrySubmitted: () => {};
-  entryCancelled: () => {};
-  closeComponent: () => {};
 };

--- a/src/widgets/notes/visit-note.component.tsx
+++ b/src/widgets/notes/visit-note.component.tsx
@@ -19,6 +19,7 @@ import {
   visitNotePayload,
   convertToObsPayLoad
 } from "./visit-note.util";
+import { DataCaptureComponentProps } from "../shared-utils";
 
 const FORM_CONCEPT: string = "c75f120a-04ec-11e3-8780-2b40bef9a44b";
 const ENCOUNTER_TYPE: string = "d7151f82-c1f3-4152-a605-2f9ea7414a79";
@@ -527,13 +528,6 @@ export default function VisitNotes(props: VisitNotesProp) {
 }
 
 type VisitNotesProp = DataCaptureComponentProps & {};
-
-type DataCaptureComponentProps = {
-  entryStarted: Function;
-  entrySubmitted: Function;
-  entryCancelled: Function;
-  closeComponent: Function;
-};
 
 VisitNotes.defaultProps = {
   entryStarted: () => {},

--- a/src/widgets/programs/programs-form.component.tsx
+++ b/src/widgets/programs/programs-form.component.tsx
@@ -15,6 +15,7 @@ import SummaryCard from "../../ui-components/cards/summary-card.component";
 import dayjs from "dayjs";
 import { filter, includes, map } from "lodash-es";
 import { useHistory } from "react-router-dom";
+import { DataCaptureComponentProps } from "../shared-utils";
 
 export default function ProgramsForm(props: ProgramsFormProps) {
   const formRef = useRef<HTMLFormElement>(null);
@@ -439,11 +440,4 @@ type ProgramEnrollment = {
   dateEnrolled?: string;
   dateCompleted?: string;
   location?: string;
-};
-
-type DataCaptureComponentProps = {
-  entryStarted: () => {};
-  entrySubmitted: () => {};
-  entryCancelled: () => {};
-  closeComponent: () => {};
 };

--- a/src/widgets/shared-utils.tsx
+++ b/src/widgets/shared-utils.tsx
@@ -1,10 +1,9 @@
 import { newWorkspaceItem } from "@openmrs/esm-api";
 
-export function openWorkspaceTab<TProps, TParams = any>(
-  componentToAdd: React.FC<TProps | DataCaptureComponentProps>,
-  componentName: string,
-  params?: TParams
-) {
+export function openWorkspaceTab<
+  TProps = DataCaptureComponentProps,
+  TParams = any
+>(componentToAdd: React.FC<TProps>, componentName: string, params?: TParams) {
   newWorkspaceItem({
     component: componentToAdd,
     name: componentName,

--- a/src/widgets/shared-utils.tsx
+++ b/src/widgets/shared-utils.tsx
@@ -1,6 +1,10 @@
 import { newWorkspaceItem } from "@openmrs/esm-api";
 
-export const openWorkspaceTab = (componentToAdd, componentName, params?) => {
+export function openWorkspaceTab<TProps, TParams = any>(
+  componentToAdd: React.FC<TProps | DataCaptureComponentProps>,
+  componentName: string,
+  params?: TParams
+) {
   newWorkspaceItem({
     component: componentToAdd,
     name: componentName,
@@ -11,4 +15,11 @@ export const openWorkspaceTab = (componentToAdd, componentName, params?) => {
     validations: (workspaceTabs: Array<{ component: React.FC }>) =>
       workspaceTabs.findIndex(tab => tab.component === componentToAdd)
   });
+}
+
+export type DataCaptureComponentProps = {
+  entryStarted: () => void;
+  entrySubmitted: () => void;
+  entryCancelled: () => void;
+  closeComponent: () => void;
 };

--- a/src/widgets/vitals/vitals-form.component.tsx
+++ b/src/widgets/vitals/vitals-form.component.tsx
@@ -12,6 +12,7 @@ import {
 import dayjs from "dayjs";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { difference } from "lodash-es";
+import { DataCaptureComponentProps } from "../shared-utils";
 
 export default function VitalsForm(props: vitalsFormProp) {
   const [enableButtons, setEnableButtons] = useState(false);
@@ -844,11 +845,4 @@ export type Vitals = {
   temperature: number;
   oxygenSaturation: number;
   heartRate: number;
-};
-
-type DataCaptureComponentProps = {
-  entryStarted: Function;
-  entrySubmitted: Function;
-  entryCancelled: Function;
-  closeComponent: Function;
 };


### PR DESCRIPTION
Final bits of work on https://issues.openmrs.org/browse/MF-184.

Properly type `openWorkspaceTab` and `DataCaptureComponentProps`. Also, `DataCaptureComponentProps` is now reusable.