### PR TITLE
MF-171: Changes to the allergies widget following switch to FHIR2

### DIFF
--- a/__mocks__/allergies.mock.ts
+++ b/__mocks__/allergies.mock.ts
@@ -1016,656 +1016,110 @@ export const mockEnvironmentalAllergens = [
 ];
 
 export const mockPatientAllergy = {
-  headers: null,
-  ok: true,
-  redirected: true,
-  status: 200,
-  statusText: "ok",
-  trailer: null,
-  type: null,
-  url: "",
-  clone: null,
-  body: null,
-  bodyUsed: null,
-  arrayBuffer: null,
-  blob: null,
-  formData: null,
-  json: null,
-  text: null,
+  clinicalStatus: "Inactive",
+  criticality: "low",
+  display: "ACE inhibitors",
+  id: "4ef4abef-57b3-4df0-b5c1-41c763e34965",
+  lastUpdated: "2020-04-02T15:08:51.000+00:00",
+  note: "Severe reaction",
+  reactionManifestations: ["Angioedema", "Anaphylaxis"],
+  reactionSeverity: "severe",
+  reactionToSubstance: "ACE inhibitors",
+  recordedBy: "JJ Dick",
+  recorderType: "Practitioner",
+  recordedDate: "2020-04-02T13:27:22+00:00"
+};
+
+export const mockPatientAllergyResult = {
   data: {
-    display: "ACE inhibitors",
-    uuid: "e68fb587-486b-4894-9fc8-eba08fe682c7",
-    allergen: {
-      allergenType: "DRUG",
-      codedAllergen: {
-        uuid: "162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-        display: "ACE inhibitors",
-        name: {
-          display: "ACE inhibitors",
-          uuid: "126205BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-          name: "ACE inhibitors"
-        },
-        names: [
-          {
-            uuid: "134688BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            display: "Enzyme de conversion classe des inhibiteurs de la drogue",
-            links: [
-              {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/concept/162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/134688BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-              }
-            ]
-          },
-          {
-            uuid: "125408BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            display: "ACE-inhibitors",
-            links: [
-              {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/concept/162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/125408BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-              }
-            ]
-          },
-          {
-            uuid: "135443BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            display: "Inhibiteurs de l’ECA",
-            links: [
-              {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/concept/162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/135443BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-              }
-            ]
-          },
-          {
-            uuid: "134689BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            display: "Anjyotansen-konvèti anzim inhibiteurs klas dwòg",
-            links: [
-              {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/concept/162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/134689BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-              }
-            ]
-          },
-          {
-            uuid: "125409BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            display: "Angiotensin-converting enzyme inhibitors drug class",
-            links: [
-              {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/concept/162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/125409BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-              }
-            ]
-          },
-          {
-            uuid: "126205BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            display: "ACE inhibitors",
-            links: [
-              {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/concept/162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/126205BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-              }
-            ]
-          },
-          {
-            uuid: "127561BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            display: "Thuốc ức chế men chuyển",
-            links: [
-              {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/concept/162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/127561BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-              }
-            ]
-          }
-        ],
-        descriptions: [],
-        mappings: [
-          {
-            uuid: "275111ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            display: "CIEL: 162298",
-            links: [
-              {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/concept/162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/mapping/275111ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-              }
-            ]
-          },
-          {
-            uuid: "275109ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            display: "SNOMED CT: 41549009",
-            links: [
-              {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/concept/162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/mapping/275109ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-              }
-            ]
-          },
-          {
-            uuid: "279273ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            display: "NDF-RT NUI: N0000000181",
-            links: [
-              {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/concept/162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/mapping/279273ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-              }
-            ]
-          },
-          {
-            uuid: "275110ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            display: "NDF-RT NUI: N0000175562",
-            links: [
-              {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/concept/162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/mapping/275110ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-              }
-            ]
-          },
-          {
-            uuid: "283334ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            display: "MED-RT NUI: N0000175562",
-            links: [
-              {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/concept/162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/mapping/283334ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-              }
-            ]
-          }
-        ],
-        answers: [],
-        setMembers: [],
-        attributes: [],
-        links: [
-          {
-            rel: "self",
-            uri:
-              "http://localhost:8090/openmrs/ws/rest/v1/concept/162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-          },
-          {
-            rel: "full",
-            uri:
-              "http://localhost:8090/openmrs/ws/rest/v1/concept/162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA?v=full"
-          }
-        ],
-        resourceVersion: "2.0"
-      },
-      nonCodedAllergen: null
-    },
-    severity: {
-      uuid: "1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-      display: "Severe",
-      name: {
-        display: "Severe",
-        uuid: "1742BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-        name: "Severe",
-        locale: "en",
-        localePreferred: true,
-        conceptNameType: "FULLY_SPECIFIED",
-        links: [
-          {
-            rel: "self",
-            uri:
-              "http://localhost:8090/openmrs/ws/rest/v1/concept/1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/1742BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-          },
-          {
-            rel: "full",
-            uri:
-              "http://localhost:8090/openmrs/ws/rest/v1/concept/1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/1742BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB?v=full"
-          }
-        ],
-        resourceVersion: "1.9"
-      },
-      datatype: {
-        uuid: "8d4a4c94-c2cc-11de-8d13-0010c6dffd0f",
-        display: "N/A",
-        links: [
-          {
-            rel: "self",
-            uri:
-              "http://localhost:8090/openmrs/ws/rest/v1/conceptdatatype/8d4a4c94-c2cc-11de-8d13-0010c6dffd0f"
-          }
-        ]
-      },
-      conceptClass: {
-        uuid: "8d491a9a-c2cc-11de-8d13-0010c6dffd0f",
-        display: "Finding",
-        links: [
-          {
-            rel: "self",
-            uri:
-              "http://localhost:8090/openmrs/ws/rest/v1/conceptclass/8d491a9a-c2cc-11de-8d13-0010c6dffd0f"
-          }
-        ]
-      },
-      set: false,
-      version: "",
-      retired: false,
-      names: [
-        {
-          uuid: "106144BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-          display: "SÉVÈRE",
-          links: [
-            {
-              rel: "self",
-              uri:
-                "http://localhost:8090/openmrs/ws/rest/v1/concept/1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/106144BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-            }
-          ]
-        },
-        {
-          uuid: "1742BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-          display: "Severe",
-          links: [
-            {
-              rel: "self",
-              uri:
-                "http://localhost:8090/openmrs/ws/rest/v1/concept/1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/1742BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-            }
-          ]
-        },
-        {
-          uuid: "134599BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-          display: "Sevè",
-          links: [
-            {
-              rel: "self",
-              uri:
-                "http://localhost:8090/openmrs/ws/rest/v1/concept/1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/134599BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-            }
-          ]
-        }
-      ],
-      descriptions: [
-        {
-          uuid: "16229FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-          display: "General qualifier value for the severity assesment",
-          links: [
-            {
-              rel: "self",
-              uri:
-                "http://localhost:8090/openmrs/ws/rest/v1/concept/1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/description/16229FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
-            }
-          ]
-        }
-      ],
-      mappings: [
-        {
-          uuid: "133263ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-          display: "PIH: 1903",
-          links: [
-            {
-              rel: "self",
-              uri:
-                "http://localhost:8090/openmrs/ws/rest/v1/concept/1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/mapping/133263ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-            }
-          ]
-        },
-        {
-          uuid: "135122ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-          display: "AMPATH: 1745",
-          links: [
-            {
-              rel: "self",
-              uri:
-                "http://localhost:8090/openmrs/ws/rest/v1/concept/1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/mapping/135122ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-            }
-          ]
-        },
-        {
-          uuid: "171742ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-          display: "CIEL: 1500",
-          links: [
-            {
-              rel: "self",
-              uri:
-                "http://localhost:8090/openmrs/ws/rest/v1/concept/1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/mapping/171742ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-            }
-          ]
-        },
-        {
-          uuid: "132651ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-          display: "SNOMED CT: 24484000",
-          links: [
-            {
-              rel: "self",
-              uri:
-                "http://localhost:8090/openmrs/ws/rest/v1/concept/1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/mapping/132651ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-            }
-          ]
-        }
-      ],
-      answers: [],
-      setMembers: [],
-      attributes: [],
-      links: [
-        {
-          rel: "self",
-          uri:
-            "http://localhost:8090/openmrs/ws/rest/v1/concept/1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        },
-        {
-          rel: "full",
-          uri:
-            "http://localhost:8090/openmrs/ws/rest/v1/concept/1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA?v=full"
-        }
-      ],
-      resourceVersion: "2.0"
-    },
-    comment: "Patient Allergy comments",
-    reactions: [
+    total: 2,
+    entry: [
       {
-        reaction: {
-          uuid: "121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          display: "Mental status change",
-          name: {
-            display: "Mental status change",
-            uuid: "127084BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            name: "Mental status change",
-            locale: "en",
-            localePreferred: true,
-            conceptNameType: null,
-            links: [
+        resource: {
+          resourceType: "AllergyIntolerance",
+          id: "67a8dad8-0d35-4afd-a838-f96913614c53",
+          category: ["medication"],
+          criticality: "?",
+          code: {
+            coding: [
               {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/concept/121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/127084BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-              },
-              {
-                rel: "full",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/concept/121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/127084BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB?v=full"
+                system: "http://openmrs.org",
+                code: "162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                display: "ACE inhibitors"
               }
             ],
-            resourceVersion: "1.9"
+            text: "ACE inhibitors"
           },
-          datatype: {
-            uuid: "8d4a4c94-c2cc-11de-8d13-0010c6dffd0f",
-            display: "N/A",
-            links: [
-              {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/conceptdatatype/8d4a4c94-c2cc-11de-8d13-0010c6dffd0f"
-              }
-            ]
-          },
-          conceptClass: {
-            uuid: "8d4918b0-c2cc-11de-8d13-0010c6dffd0f",
-            display: "Diagnosis",
-            links: [
-              {
-                rel: "self",
-                uri:
-                  "http://localhost:8090/openmrs/ws/rest/v1/conceptclass/8d4918b0-c2cc-11de-8d13-0010c6dffd0f"
-              }
-            ]
-          },
-          set: false,
-          version: "",
-          retired: false,
-          names: [
+          note: [
             {
-              uuid: "134528BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-              display: "Le changement de l'état mental",
-              links: [
-                {
-                  rel: "self",
-                  uri:
-                    "http://localhost:8090/openmrs/ws/rest/v1/concept/121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/134528BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-                }
-              ]
-            },
-            {
-              uuid: "134529BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-              display: "Chanjman eta mantal",
-              links: [
-                {
-                  rel: "self",
-                  uri:
-                    "http://localhost:8090/openmrs/ws/rest/v1/concept/121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/134529BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-                }
-              ]
-            },
-            {
-              uuid: "21808BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-              display: "Altered Mental Status",
-              links: [
-                {
-                  rel: "self",
-                  uri:
-                    "http://localhost:8090/openmrs/ws/rest/v1/concept/121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/21808BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-                }
-              ]
-            },
-            {
-              uuid: "80786BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-              display: "estado mental alterado",
-              links: [
-                {
-                  rel: "self",
-                  uri:
-                    "http://localhost:8090/openmrs/ws/rest/v1/concept/121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/80786BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-                }
-              ]
-            },
-            {
-              uuid: "127084BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-              display: "Mental status change",
-              links: [
-                {
-                  rel: "self",
-                  uri:
-                    "http://localhost:8090/openmrs/ws/rest/v1/concept/121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/name/127084BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-                }
-              ]
+              text: "comment"
             }
           ],
-          descriptions: [],
-          mappings: [
+          reaction: [
             {
-              uuid: "185768ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-              display: "CIEL: 121677",
-              links: [
+              manifestation: [
                 {
-                  rel: "self",
-                  uri:
-                    "http://localhost:8090/openmrs/ws/rest/v1/concept/121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/mapping/185768ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+                  coding: [
+                    {
+                      system: "http://openmrs.org",
+                      code: "124AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                      display: "Anaphylaxis"
+                    }
+                  ],
+                  text: "Anaphylaxis"
                 }
               ]
-            },
-            {
-              uuid: "70242ABBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-              display: "SNOMED CT: 419284004",
-              links: [
-                {
-                  rel: "self",
-                  uri:
-                    "http://localhost:8090/openmrs/ws/rest/v1/concept/121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/mapping/70242ABBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-                }
-              ]
-            },
-            {
-              uuid: "266979ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-              display: "IMO ProblemIT: 72276",
-              links: [
-                {
-                  rel: "self",
-                  uri:
-                    "http://localhost:8090/openmrs/ws/rest/v1/concept/121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/mapping/266979ABBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-                }
-              ]
-            },
-            {
-              uuid: "95967ABBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-              display: "ICD-10-WHO: F99",
-              links: [
-                {
-                  rel: "self",
-                  uri:
-                    "http://localhost:8090/openmrs/ws/rest/v1/concept/121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/mapping/95967ABBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-                }
-              ]
-            }
-          ],
-          answers: [],
-          setMembers: [],
-          attributes: [],
-          links: [
-            {
-              rel: "self",
-              uri:
-                "http://localhost:8090/openmrs/ws/rest/v1/concept/121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-            },
-            {
-              rel: "full",
-              uri:
-                "http://localhost:8090/openmrs/ws/rest/v1/concept/121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA?v=full"
-            }
-          ],
-          resourceVersion: "2.0"
-        },
-        reactionNonCoded: null
-      }
-    ],
-    patient: {
-      uuid: "90f7f0b4-06a8-4a97-9678-e7a977f4b518",
-      display: "10010W - John Taylor",
-      identifiers: [
-        {
-          uuid: "21bb350c-799b-4837-9496-2ad213e058a4",
-          display: "OpenMRS ID = 10010W",
-          links: [
-            {
-              rel: "self",
-              uri:
-                "http://localhost:8090/openmrs/ws/rest/v1/patient/90f7f0b4-06a8-4a97-9678-e7a977f4b518/identifier/21bb350c-799b-4837-9496-2ad213e058a4"
             }
           ]
         }
-      ],
-      person: {
-        uuid: "90f7f0b4-06a8-4a97-9678-e7a977f4b518",
-        display: "John Taylor",
-        gender: "M",
-        age: 41,
-        birthdate: "1978-08-25T00:00:00.000+0000",
-        birthdateEstimated: false,
-        dead: false,
-        deathDate: null,
-        causeOfDeath: null,
-        preferredName: {
-          uuid: "4b68f067-6f4d-451a-bd80-342fc21ea486",
-          display: "John Taylor",
-          links: [
-            {
-              rel: "self",
-              uri:
-                "http://localhost:8090/openmrs/ws/rest/v1/person/90f7f0b4-06a8-4a97-9678-e7a977f4b518/name/4b68f067-6f4d-451a-bd80-342fc21ea486"
-            }
-          ]
-        },
-        preferredAddress: {
-          uuid: "e350d53f-0252-4259-8d87-d97a2d58166e",
-          display: "Police Line",
-          links: [
-            {
-              rel: "self",
-              uri:
-                "http://localhost:8090/openmrs/ws/rest/v1/person/90f7f0b4-06a8-4a97-9678-e7a977f4b518/address/e350d53f-0252-4259-8d87-d97a2d58166e"
-            }
-          ]
-        },
-        attributes: [],
-        voided: false,
-        deathdateEstimated: false,
-        birthtime: null,
-        links: [
-          {
-            rel: "self",
-            uri:
-              "http://localhost:8090/openmrs/ws/rest/v1/person/90f7f0b4-06a8-4a97-9678-e7a977f4b518"
-          },
-          {
-            rel: "full",
-            uri:
-              "http://localhost:8090/openmrs/ws/rest/v1/person/90f7f0b4-06a8-4a97-9678-e7a977f4b518?v=full"
-          }
-        ],
-        resourceVersion: "1.11"
       },
-      voided: false,
-      links: [
-        {
-          rel: "self",
-          uri:
-            "http://localhost:8090/openmrs/ws/rest/v1/patient/90f7f0b4-06a8-4a97-9678-e7a977f4b518"
-        },
-        {
-          rel: "full",
-          uri:
-            "http://localhost:8090/openmrs/ws/rest/v1/patient/90f7f0b4-06a8-4a97-9678-e7a977f4b518?v=full"
-        }
-      ],
-      resourceVersion: "1.8"
-    },
-    voided: true,
-    auditInfo: {
-      creator: {
-        uuid: "285f67ce-3d8b-4733-96e5-1e2235e8e804",
-        display: "doc",
-        links: [
-          {
-            rel: "self",
-            uri:
-              "http://localhost:8090/openmrs/ws/rest/v1/user/285f67ce-3d8b-4733-96e5-1e2235e8e804"
-          }
-        ]
-      },
-      dateCreated: "2019-12-16T07:10:36.000+0000",
-      changedBy: {
-        uuid: "285f67ce-3d8b-4733-96e5-1e2235e8e804",
-        display: "doc",
-        links: [
-          {
-            rel: "self",
-            uri:
-              "http://localhost:8090/openmrs/ws/rest/v1/user/285f67ce-3d8b-4733-96e5-1e2235e8e804"
-          }
-        ]
-      },
-      dateChanged: "2019-12-16T07:46:42.000+0000",
-      voidedBy: {
-        uuid: "285f67ce-3d8b-4733-96e5-1e2235e8e804",
-        display: "doc",
-        links: [
-          {
-            rel: "self",
-            uri:
-              "http://localhost:8090/openmrs/ws/rest/v1/user/285f67ce-3d8b-4733-96e5-1e2235e8e804"
-          }
-        ]
-      },
-      dateVoided: "2019-12-16T07:46:42.000+0000",
-      voidReason: "web service call"
-    },
-    links: [
       {
-        rel: "self",
-        uri:
-          "http://localhost:8090/openmrs/ws/rest/v1/patient/90f7f0b4-06a8-4a97-9678-e7a977f4b518/allergy/e68fb587-486b-4894-9fc8-eba08fe682c7"
+        resource: {
+          resourceType: "AllergyIntolerance",
+          id: "b6c8efa1-e823-46ac-ae09-83b2b0b96a48",
+          extension: [
+            {
+              url:
+                "http://fhir-es.transcendinsights.com/stu3/StructureDefinition/resource-date-created",
+              valueDateTime: "2019-06-21T13:43:47+00:00"
+            },
+            {
+              url:
+                "https://purl.org/elab/fhir/StructureDefinition/Creator-crew-version1",
+              valueString: "user2"
+            }
+          ],
+          category: ["medication"],
+          criticality: "low",
+          code: {
+            coding: [
+              {
+                system: "http://openmrs.org",
+                code: "162299AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                display: "ARBs (angiotensin II receptor blockers)"
+              }
+            ],
+            text: "ARBs (angiotensin II receptor blockers)"
+          },
+          reaction: [
+            {
+              manifestation: [
+                {
+                  coding: [
+                    {
+                      system: "http://openmrs.org",
+                      code: "124AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                      display: "Mental status change"
+                    }
+                  ],
+                  text: "Mental status change"
+                }
+              ]
+            }
+          ]
+        }
       }
-    ],
-    resourceVersion: "1.8"
+    ]
   }
 };
 
@@ -1675,6 +1129,9 @@ export const mockAllergyResult = {
     uuid: "90c17541-833d-419e-b5d3-bc06828bf95f",
     allergen: {
       allergenType: "DRUG",
+      codedAllergen: {
+        display: "ARBs (angiotensin II receptor blockers)"
+      },
       nonCodedAllergen: null
     },
     severity: {
@@ -1720,98 +1177,105 @@ export const mockAllergyResult = {
   }
 };
 
-export const mockPatientAllergyResult = {
+export const mockUpdatedAllergyResult = {
   data: {
-    total: 2,
-    entry: [
-      {
-        resource: {
-          resourceType: "AllergyIntolerance",
-          id: "67a8dad8-0d35-4afd-a838-f96913614c53",
-          category: ["medication"],
-          criticality: "?",
-          code: {
-            coding: [
-              {
-                system: "http://openmrs.org",
-                code: "162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                display: "ACE inhibitors"
-              }
-            ],
-            text: "ACE inhibitors"
-          },
-          note: [
-            {
-              text: "comment"
-            }
-          ],
-          reaction: [
-            {
-              manifestation: [
-                {
-                  coding: [
-                    {
-                      system: "http://openmrs.org",
-                      code: "124AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      display: "AMOEBIASIS"
-                    }
-                  ],
-                  text: "AMOEBIASIS"
-                }
-              ]
-            }
-          ]
-        }
+    display: "ARBs (angiotensin II receptor blockers)",
+    uuid: "90c17541-833d-419e-b5d3-bc06828bf95f",
+    allergen: {
+      allergenType: "DRUG",
+      codedAllergen: {
+        display: "ARBs (angiotensin II receptor blockers)"
       },
+      nonCodedAllergen: null
+    },
+    severity: {
+      uuid: "1498AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      display: "Mild",
+      name: {
+        display: "Mild",
+        uuid: "1738BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+        name: "Mild",
+        locale: "en",
+        localePreferred: true,
+        conceptNameType: "FULLY_SPECIFIED"
+      }
+    },
+    comment:
+      "The patient is showing a mild reaction to Angiotensin II receptor blockers. Low dose antihistamines prescribed",
+    reactions: [
       {
-        resource: {
-          resourceType: "AllergyIntolerance",
-          id: "b6c8efa1-e823-46ac-ae09-83b2b0b96a48",
-          extension: [
-            {
-              url:
-                "http://fhir-es.transcendinsights.com/stu3/StructureDefinition/resource-date-created",
-              valueDateTime: "2019-06-21T13:43:47+00:00"
-            },
-            {
-              url:
-                "https://purl.org/elab/fhir/StructureDefinition/Creator-crew-version1",
-              valueString: "user2"
-            }
-          ],
-          category: ["medication"],
-          criticality: "low",
-          code: {
-            coding: [
-              {
-                system: "http://openmrs.org",
-                code: "162299AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                display: "ARBs (angiotensin II receptor blockers)"
-              }
-            ],
-            text: "ARBs (angiotensin II receptor blockers)"
-          },
-          reaction: [
-            {
-              manifestation: [
-                {
-                  coding: [
-                    {
-                      system: "http://openmrs.org",
-                      code: "124AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      display: "AMOEBIASIS"
-                    }
-                  ],
-                  text: "AMOEBIASIS"
-                }
-              ]
-            }
-          ]
+        reaction: {
+          uuid: "121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          display: "Mental status change",
+          name: {
+            display: "Mental status change",
+            uuid: "127084BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            name: "Mental status change",
+            locale: "en",
+            localePreferred: true,
+            conceptNameType: null
+          }
         }
       }
-    ]
+    ],
+    patient: {
+      uuid: "90f7f0b4-06a8-4a97-9678-e7a977f4b518",
+      display: "10010W - John Taylor"
+    },
+    auditInfo: {
+      creator: {
+        uuid: "285f67ce-3d8b-4733-96e5-1e2235e8e804",
+        display: "doc"
+      },
+      dateChanged: "2020-01-03T07:05:12.000+0000"
+    }
   }
 };
+
+export const mockPatientAllergies = [
+  {
+    id: "59fd4be3-1a14-40a6-b1d7-8d0c6a124105",
+    criticality: "low",
+    clinicalStatus: "Inactive",
+    display: "Cephalosporins",
+    recordedDate: "2019-12-20T01:40:38+00:00",
+    recordedBy: "Ronaldo Messi",
+    recorderType: "Practitioner",
+    note: "happened today",
+    reactionToSubstance: "Cephalosporins",
+    reactionManifestations: ["Angioedema"],
+    reactionSeverity: "severe",
+    lastUpdated: "2020-04-02T08:05:49.000+00:00"
+  },
+  {
+    id: "99300205-4653-455f-93fa-692916f9c891",
+    clinicalStatus: "Inactive",
+    criticality: "low",
+    display: "Peanuts",
+    recordedDate: "2019-12-20T01:41:51+00:00",
+    recordedBy: "Ronaldo Messi",
+    recorderType: "Practitioner",
+    note: "test",
+    reactionToSubstance: "Peanuts",
+    reactionManifestations: ["Anaphylaxis"],
+    reactionSeverity: "mild",
+    lastUpdated: "2020-04-02T08:06:01.000+00:00"
+  },
+  {
+    id: "4ef4abef-57b3-4df0-b5c1-41c763e34965",
+    clinicalStatus: "Active",
+    criticality: "high",
+    display: "ACE inhibitors",
+    recordedDate: "2020-04-02T13:27:22+00:00",
+    recordedBy: "JJ Dick",
+    recorderType: "Practitioner",
+    note: "Severe reaction",
+    reactionToSubstance: "ACE inhibitors",
+    reactionManifestations: ["Angioedema", "Anaphylaxis"],
+    reactionSeverity: "severe",
+    lastUpdated: "2020-04-02T15:08:51.000+00:00"
+  }
+];
 
 export const mockPatientAllergyResultWithoutOnsetDate = {
   data: {
@@ -1993,4 +1457,84 @@ export const mockPatientAllergyResultWithoutOnsetDate = {
       }
     ]
   }
+};
+
+export const mockSaveAllergyResponse = {
+  display: "Bee stings",
+  uuid: "ec0be2bb-2922-4882-bc4b-01939fac72c2",
+  allergen: {
+    allergenType: "ENVIRONMENT",
+    codedAllergen: {
+      uuid: "162536AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      display: "Bee stings",
+      links: [
+        {
+          rel: "self",
+          uri:
+            "http://localhost:8090/openmrs/ws/rest/v1/concept/162536AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      ]
+    },
+    nonCodedAllergen: null
+  },
+  severity: {
+    uuid: "1498AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    display: "Mild",
+    links: [
+      {
+        rel: "self",
+        uri:
+          "http://localhost:8090/openmrs/ws/rest/v1/concept/1498AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      }
+    ]
+  },
+  comment:
+    "Patient was tilling farmland when he was ambushed by a swarm of bees and stung several times.",
+  reactions: [
+    {
+      reaction: {
+        uuid: "512AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        display: "Rash",
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/concept/512AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          }
+        ]
+      },
+      reactionNonCoded: null
+    },
+    {
+      reaction: {
+        uuid: "111061AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        display: "Hives",
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/concept/111061AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          }
+        ]
+      },
+      reactionNonCoded: null
+    }
+  ],
+  patient: {
+    uuid: "90f7f0b4-06a8-4a97-9678-e7a977f4b518",
+    display: "10010W - John Taylor"
+  },
+  links: [
+    {
+      rel: "self",
+      uri:
+        "http://localhost:8090/openmrs/ws/rest/v1/patient/070f0120-0283-4858-885d-a20d967729cf/allergy/ec0be2bb-2922-4882-bc4b-01939fac72c2"
+    },
+    {
+      rel: "full",
+      uri:
+        "http://localhost:8090/openmrs/ws/rest/v1/patient/070f0120-0283-4858-885d-a20d967729cf/allergy/ec0be2bb-2922-4882-bc4b-01939fac72c2?v=full"
+    }
+  ],
+  resourceVersion: "1.8"
 };

--- a/__mocks__/allergies.mock.ts
+++ b/__mocks__/allergies.mock.ts
@@ -1130,7 +1130,8 @@ export const mockAllergyResult = {
     allergen: {
       allergenType: "DRUG",
       codedAllergen: {
-        display: "ARBs (angiotensin II receptor blockers)"
+        display: "ARBs (angiotensin II receptor blockers)",
+        uuid: "921fbd85-fa49-46c3-9ee1-77e093fd10a5"
       },
       nonCodedAllergen: null
     },

--- a/__mocks__/allergies.mock.ts
+++ b/__mocks__/allergies.mock.ts
@@ -1275,6 +1275,20 @@ export const mockPatientAllergies = [
     reactionManifestations: ["Angioedema", "Anaphylaxis"],
     reactionSeverity: "severe",
     lastUpdated: "2020-04-02T15:08:51.000+00:00"
+  },
+  {
+    id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518",
+    clinicalStatus: "Active",
+    criticality: "high",
+    display: "Sulfonamides",
+    recordedDate: "2020-04-08T11:00:22+00:00",
+    recordedBy: "JJ Dick",
+    recorderType: "Practitioner",
+    note: "Severe reaction",
+    reactionToSubstance: "ACE inhibitors",
+    reactionManifestations: ["Anaphylaxis", "Severe blistering rash"],
+    reactionSeverity: "severe",
+    lastUpdated: "2020-04-08T11:00:22.000+00:00"
   }
 ];
 

--- a/src/widgets/allergies/allergies-detailed-summary.component.tsx
+++ b/src/widgets/allergies/allergies-detailed-summary.component.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Link, useRouteMatch } from "react-router-dom";
 import { performPatientAllergySearch } from "./allergy-intolerance.resource";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
@@ -8,11 +8,12 @@ import dayjs from "dayjs";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import AllergyForm from "./allergy-form.component";
 import { openWorkspaceTab } from "../shared-utils";
+import EmptyState from "../../ui-components/empty-state/empty-state.component";
 
 export default function AllergiesDetailedSummary(
   props: AllergiesDetailedSummaryProps
 ) {
-  const [patientAllergy, setPatientAllergy] = React.useState(null);
+  const [patientAllergies, setPatientAllergies] = useState(null);
   const [
     isLoadingPatient,
     patient,
@@ -21,100 +22,94 @@ export default function AllergiesDetailedSummary(
   ] = useCurrentPatient();
   const match = useRouteMatch();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!isLoadingPatient && patient) {
-      const abortController = new AbortController();
+      const sub = performPatientAllergySearch(
+        patient.identifier[0].value
+      ).subscribe(allergies => {
+        setPatientAllergies(allergies), createErrorHandler();
+      });
 
-      performPatientAllergySearch(patient.identifier[0].value, abortController)
-        .then(allergy => setPatientAllergy(allergy.data))
-        .catch(createErrorHandler());
-
-      return () => abortController.abort();
+      return () => sub.unsubscribe();
     }
   }, [isLoadingPatient, patient]);
 
-  function displayAllergy() {
-    return (
-      <SummaryCard
-        name="Allergies"
-        styles={{ width: "100%" }}
-        addComponent={AllergyForm}
-        showComponent={() =>
-          openWorkspaceTab(AllergyForm, "Allergy Form", {
-            allergyUuid: null
-          })
-        }
-      >
-        <table className={styles.allergyTable}>
-          <thead>
-            <tr>
-              <td>ALLERGEN</td>
-              <td>
-                <div className={styles.centerItems}>
-                  SEVERITY & REACTION
-                  <svg className="omrs-icon" fill="rgba(0, 0, 0, 0.54)">
-                    <use xlinkHref="#omrs-icon-arrow-downward" />
-                  </svg>
-                </div>
-              </td>
-              <td>SINCE</td>
-              <td>UPDATED</td>
-            </tr>
-          </thead>
-          <tbody>
-            {patientAllergy &&
-              patientAllergy.entry.map(allergy => {
+  return (
+    <>
+      {patientAllergies?.length ? (
+        <SummaryCard
+          name="Allergies"
+          styles={{ width: "100%" }}
+          addComponent={AllergyForm}
+          showComponent={() =>
+            openWorkspaceTab(AllergyForm, "Allergies Form", {
+              allergyUuid: null
+            })
+          }
+        >
+          <table className={`omrs-type-body-regular ${styles.allergyTable}`}>
+            <thead>
+              <tr>
+                <td>ALLERGEN</td>
+                <td>
+                  <div className={styles.centerItems}>
+                    SEVERITY & REACTION
+                    <svg className="omrs-icon" fill="rgba(0, 0, 0, 0.54)">
+                      <use xlinkHref="#omrs-icon-arrow-downward" />
+                    </svg>
+                  </div>
+                </td>
+                <td>SINCE</td>
+                <td>UPDATED</td>
+              </tr>
+            </thead>
+            <tbody>
+              {patientAllergies.map(allergy => {
                 return (
-                  <React.Fragment key={allergy.resource.id}>
+                  <React.Fragment key={allergy?.id}>
                     <tr
                       className={`${
-                        allergy.resource.criticality === "high"
+                        allergy?.criticality === "high"
                           ? `${styles.high}`
                           : `${styles.low}`
                       }`}
                     >
-                      <td className={"omrs-bold"}>
-                        {allergy.resource.code.text}
-                      </td>
+                      <td className={styles.allergyName}>{allergy?.display}</td>
                       <td>
                         <div
                           className={`${styles.centerItems} ${
-                            allergy.resource.criticality === "high"
-                              ? `omrs-bold`
-                              : ``
+                            styles.allergySeverity
+                          } ${
+                            allergy?.criticality === "high" ? `omrs-bold` : ``
                           }`}
                           style={{ textTransform: "uppercase" }}
                         >
-                          {allergy.resource.criticality === "high" && (
+                          {allergy?.criticality === "high" && (
                             <svg
-                              className={`omrs-icon`}
-                              fontSize={"15px"}
+                              className="omrs-icon"
                               fill="rgba(181, 7, 6, 1)"
+                              style={{ height: "1.833rem" }}
                             >
                               <use xlinkHref="#omrs-icon-important-notification" />
                             </svg>
                           )}
-                          {allergy.resource.criticality}
+                          {allergy?.criticality}
                         </div>
                       </td>
                       <td>
-                        {dayjs(
-                          allergy?.resource?.extension?.[0]?.valueDateTime
-                        ).format("MMM-YYYY") ?? "-"}
+                        {dayjs(allergy?.recordedDate).format("MMM-YYYY") ?? "-"}
                       </td>
                       <td>
                         <div
                           className={`${styles.centerItems} ${styles.alignRight}`}
                         >
                           <span>
-                            {dayjs(patientAllergy.meta.lastUpdated).format(
+                            {dayjs(patientAllergies?.lastUpdated).format(
                               "DD-MMM-YYYY"
                             )}
                           </span>
 
-                          <Link
-                            to={`${match.path}/details/${allergy.resource.id}`}
-                          >
+                          <Link to={`${match.path}/details/${allergy?.id}`}>
                             <svg
                               className="omrs-icon"
                               fill="rgba(0, 0, 0, 0.54)"
@@ -127,86 +122,37 @@ export default function AllergiesDetailedSummary(
                     </tr>
                     <tr>
                       <td></td>
-                      <td colSpan={3}>
-                        {Object.values(
-                          allergy.resource.reaction[0].manifestation.map(
-                            manifestation => manifestation.text
-                          )
-                        ).join(", ")}
+                      <td style={{ textAlign: "left" }}>
+                        {allergy?.reactionManifestations?.join(", ")}
                       </td>
                     </tr>
                     <tr>
                       <td></td>
                       <td colSpan={3}>
                         <span className={`${styles.allergyComment}`}>
-                          <span style={{ whiteSpace: "pre-line" }}>
-                            {allergy.resource.note &&
-                              allergy.resource.note[0].text}
+                          <span style={{ textAlign: "left" }}>
+                            {allergy?.note}
                           </span>
-                          <Link
-                            className="omrs-unstyled"
-                            to={`${match.path}/details/${allergy.resource.id}`}
-                          >
-                            more ...
-                          </Link>
                         </span>
                       </td>
                     </tr>
                   </React.Fragment>
                 );
               })}
-          </tbody>
-        </table>
-        <div className={`allergyFooter ${styles.allergyFooter}`}>
-          <p>No more allergies available</p>
-        </div>
-      </SummaryCard>
-    );
-  }
-
-  function displayNoAllergenHistory() {
-    return (
-      <SummaryCard
-        name="Allergies"
-        styles={{ width: "100%" }}
-        addComponent={AllergyForm}
-        showComponent={() =>
-          openWorkspaceTab(AllergyForm, "Allergy Form", {
-            allergyUuid: null
-          })
-        }
-      >
-        <div className={styles.allergyMargin}>
-          <p className="omrs-bold">
-            The patient's allergy history is not documented.
-          </p>
-          <p className="omrs-bold">
-            <button
-              style={{ cursor: "pointer" }}
-              className="omrs-btn omrs-outlined-action"
-              type="button"
-              onClick={() =>
-                openWorkspaceTab(AllergyForm, "Allergy Form", {
-                  allergyUuid: null
-                })
-              }
-            >
-              Add allergy history
-            </button>
-          </p>
-        </div>
-      </SummaryCard>
-    );
-  }
-
-  return (
-    <>
-      {patientAllergy && (
-        <div className={styles.allergySummary}>
-          {patientAllergy.total > 0
-            ? displayAllergy()
-            : displayNoAllergenHistory()}
-        </div>
+            </tbody>
+          </table>
+        </SummaryCard>
+      ) : (
+        <EmptyState
+          name="Allergies"
+          showComponent={() =>
+            openWorkspaceTab(AllergyForm, "Allergies Form", {
+              allergyUuid: null
+            })
+          }
+          addComponent={AllergyForm}
+          displayText="This patient has no allergy intolerances recorded in the system."
+        />
       )}
     </>
   );

--- a/src/widgets/allergies/allergies-detailed-summary.component.tsx
+++ b/src/widgets/allergies/allergies-detailed-summary.component.tsx
@@ -25,8 +25,8 @@ export default function AllergiesDetailedSummary(
       const sub = performPatientAllergySearch(
         patient.identifier[0].value
       ).subscribe(allergies => {
-        setPatientAllergies(allergies), createErrorHandler();
-      });
+        setPatientAllergies(allergies);
+      }, createErrorHandler());
 
       return () => sub.unsubscribe();
     }
@@ -72,7 +72,7 @@ export default function AllergiesDetailedSummary(
                           : `${styles.low}`
                       }`}
                     >
-                      <td className={styles.allergyName}>{allergy?.display}</td>
+                      <td className="omrs-medium">{allergy?.display}</td>
                       <td>
                         <div
                           className={`${styles.centerItems} ${
@@ -84,7 +84,7 @@ export default function AllergiesDetailedSummary(
                         >
                           {allergy?.criticality === "high" && (
                             <svg
-                              className="omrs-icon"
+                              className="omrs-icon omrs-margin-right-4"
                               fill="rgba(181, 7, 6, 1)"
                               style={{ height: "1.833rem" }}
                             >

--- a/src/widgets/allergies/allergies-detailed-summary.component.tsx
+++ b/src/widgets/allergies/allergies-detailed-summary.component.tsx
@@ -1,6 +1,9 @@
 import React, { useState, useEffect } from "react";
 import { Link, useRouteMatch } from "react-router-dom";
-import { performPatientAllergySearch } from "./allergy-intolerance.resource";
+import {
+  performPatientAllergySearch,
+  Allergy
+} from "./allergy-intolerance.resource";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import styles from "./allergies-detailed-summary.css";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
@@ -13,7 +16,7 @@ import EmptyState from "../../ui-components/empty-state/empty-state.component";
 export default function AllergiesDetailedSummary(
   props: AllergiesDetailedSummaryProps
 ) {
-  const [patientAllergies, setPatientAllergies] = useState(null);
+  const [patientAllergies, setPatientAllergies] = useState<Allergy[]>(null);
   const [
     isLoadingPatient,
     patient,
@@ -104,11 +107,8 @@ export default function AllergiesDetailedSummary(
                           className={`${styles.centerItems} ${styles.alignRight}`}
                         >
                           <span>
-                            {dayjs(patientAllergies?.lastUpdated).format(
-                              "DD-MMM-YYYY"
-                            )}
+                            {dayjs(allergy?.lastUpdated).format("DD-MMM-YYYY")}
                           </span>
-
                           <Link to={`${match.path}/details/${allergy?.id}`}>
                             <svg
                               className="omrs-icon"
@@ -129,7 +129,7 @@ export default function AllergiesDetailedSummary(
                     <tr>
                       <td></td>
                       <td colSpan={3}>
-                        <span className={`${styles.allergyComment}`}>
+                        <span className={styles.allergyComment}>
                           <span style={{ textAlign: "left" }}>
                             {allergy?.note}
                           </span>

--- a/src/widgets/allergies/allergies-detailed-summary.component.tsx
+++ b/src/widgets/allergies/allergies-detailed-summary.component.tsx
@@ -1,28 +1,23 @@
 import React, { useState, useEffect } from "react";
 import { Link, useRouteMatch } from "react-router-dom";
+import dayjs from "dayjs";
+import { useCurrentPatient } from "@openmrs/esm-api";
+import { createErrorHandler } from "@openmrs/esm-error-handling";
+import { openWorkspaceTab } from "../shared-utils";
+import EmptyState from "../../ui-components/empty-state/empty-state.component";
+import SummaryCard from "../../ui-components/cards/summary-card.component";
 import {
   performPatientAllergySearch,
   Allergy
 } from "./allergy-intolerance.resource";
-import { createErrorHandler } from "@openmrs/esm-error-handling";
-import styles from "./allergies-detailed-summary.css";
-import SummaryCard from "../../ui-components/cards/summary-card.component";
-import dayjs from "dayjs";
-import { useCurrentPatient } from "@openmrs/esm-api";
 import AllergyForm from "./allergy-form.component";
-import { openWorkspaceTab } from "../shared-utils";
-import EmptyState from "../../ui-components/empty-state/empty-state.component";
+import styles from "./allergies-detailed-summary.css";
 
 export default function AllergiesDetailedSummary(
   props: AllergiesDetailedSummaryProps
 ) {
   const [patientAllergies, setPatientAllergies] = useState<Allergy[]>(null);
-  const [
-    isLoadingPatient,
-    patient,
-    patientUuid,
-    patientErr
-  ] = useCurrentPatient();
+  const [isLoadingPatient, patient] = useCurrentPatient();
   const match = useRouteMatch();
 
   useEffect(() => {
@@ -151,7 +146,7 @@ export default function AllergiesDetailedSummary(
             })
           }
           addComponent={AllergyForm}
-          displayText="This patient has no allergy intolerances recorded in the system."
+          displayText="allergy intolerances"
         />
       )}
     </>

--- a/src/widgets/allergies/allergies-detailed-summary.css
+++ b/src/widgets/allergies/allergies-detailed-summary.css
@@ -7,6 +7,20 @@
   padding: 0.25rem 0.5rem 0 0.5rem;
 }
 
+.allergyName {
+  font-weight: 500;
+  font-size: 1.188rem;
+}
+
+.allergySeverity {
+  font-size: 1.063rem;
+  letter-spacing: 0.063rem;
+}
+
+.allergySeverity svg {
+  margin-right: 0.375rem;
+}
+
 .allergyTable {
   width: 100%;
 }
@@ -19,6 +33,7 @@
 .allergyTable thead td {
   padding: 1rem 0.25rem 1rem 1rem;
 }
+
 :global(.omrs-breakpoint-lt-tablet) .allergyTable thead td {
   padding: 0.25rem 0.125rem 0.5rem 0.5rem;
 }
@@ -31,6 +46,7 @@
   text-align: right;
   padding-right: 2.925rem;
 }
+
 :global(.omrs-breakpoint-lt-tablet) .allergyTable thead td:nth-child(4) {
   padding-right: 1.45125rem;
 }
@@ -57,6 +73,7 @@
 :global(.omrs-breakpoint-lt-tablet) .allergyTable tbody {
   padding: 1rem;
 }
+
 .allergyTable td {
   width: 25%;
   padding: 0.5rem 0.25rem 0rem 1rem;
@@ -94,12 +111,6 @@
 .allergyComment p:nth-child(2) {
   flex: 10%;
   align-items: flex-end;
-}
-
-.allergyFooter {
-  text-align: center;
-  color: var(--omrs-color-ink-medium-contrast);
-  font-family: "Work sans";
 }
 
 tr.high {

--- a/src/widgets/allergies/allergies-detailed-summary.css
+++ b/src/widgets/allergies/allergies-detailed-summary.css
@@ -7,18 +7,9 @@
   padding: 0.25rem 0.5rem 0 0.5rem;
 }
 
-.allergyName {
-  font-weight: 500;
-  font-size: 1.188rem;
-}
-
 .allergySeverity {
   font-size: 1.063rem;
   letter-spacing: 0.063rem;
-}
-
-.allergySeverity svg {
-  margin-right: 0.375rem;
 }
 
 .allergyTable {

--- a/src/widgets/allergies/allergies-detailed-summary.test.tsx
+++ b/src/widgets/allergies/allergies-detailed-summary.test.tsx
@@ -1,354 +1,101 @@
 import React from "react";
-import { performPatientAllergySearch } from "./allergy-intolerance.resource";
-import { render, cleanup, wait } from "@testing-library/react";
-import { BrowserRouter, match } from "react-router-dom";
-import AllergiesOverviewLevelTwo from "./allergies-detailed-summary.component";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
 import { useCurrentPatient } from "../../../__mocks__/openmrs-esm-api.mock";
-import { fhirBaseUrl } from "@openmrs/esm-api";
-import { mockPatientAllergyResultWithoutOnsetDate } from "../../../__mocks__/allergy.mock";
+import { of } from "rxjs/internal/observable/of";
+import {
+  patient,
+  mockPatientAllergies
+} from "../../../__mocks__/allergies.mock";
+import { performPatientAllergySearch } from "./allergy-intolerance.resource";
+import AllergyForm from "./allergy-form.component";
+import AllergiesDetailedSummary from "./allergies-detailed-summary.component";
+import { openWorkspaceTab } from "../shared-utils";
+
 const mockPerformPatientAllergySearch = performPatientAllergySearch as jest.Mock;
 const mockUseCurrentPatient = useCurrentPatient as jest.Mock;
+const mockOpenWorkspaceTab = openWorkspaceTab as jest.Mock;
 
 jest.mock("./allergy-intolerance.resource", () => ({
   performPatientAllergySearch: jest.fn()
 }));
 
 jest.mock("@openmrs/esm-api", () => ({
-  useCurrentPatient: jest.fn(),
-  fhirBaseUrl: `/ws/fhir2`
+  useCurrentPatient: jest.fn()
 }));
 
-const mockPatientAllergyResult = {
-  data: {
-    resourceType: "Bundle",
-    id: "bbcb90f8-0e9e-4e61-885f-73eb49dce7b9",
-    meta: {
-      lastUpdated: "2019-11-12T07:36:39.592+00:00"
-    },
-    type: "searchset",
-    total: 2,
-    link: [
-      {
-        relation: "self",
-        url: `http://localhost:8080/openmrs${fhirBaseUrl}/AllergyIntolerance?patient.identifier=10010W`
-      }
-    ],
-    entry: [
-      {
-        fullUrl: `http://localhost:8080/openmrs${fhirBaseUrl}/AllergyIntolerance/0ff69971-f82a-4e3d-b59f-9e515cae7a6a`,
-        resource: {
-          resourceType: "AllergyIntolerance",
-          id: "0ff69971-f82a-4e3d-b59f-9e515cae7a6a",
-          extension: [
-            {
-              url:
-                "http://fhir-es.transcendinsights.com/stu3/StructureDefinition/resource-date-created",
-              valueDateTime: "2019-11-11T17:38:11+00:00"
-            },
-            {
-              url: "dateChanged",
-              valueDateTime: "2019-11-11T17:39:50+00:00"
-            }
-          ],
-          category: ["medication"],
-          criticality: "low",
-          code: {
-            coding: [
-              {
-                system: "http://ciel.org",
-                code: "162298"
-              },
-              {
-                system: "http://snomed.info/sct",
-                code: "41549009"
-              },
-              {
-                system:
-                  "http://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/NDFRT/",
-                code: "N0000000181"
-              },
-              {
-                system:
-                  "http://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/NDFRT/",
-                code: "N0000175562"
-              },
-              {
-                system: "med-rt nui",
-                code: "N0000175562"
-              },
-              {
-                system: "http://openmrs.org",
-                code: "162298AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                display: "ACE inhibitors"
-              }
-            ],
-            text: "ACE inhibitors"
-          },
-          patient: {
-            id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518",
-            reference: "Patient/90f7f0b4-06a8-4a97-9678-e7a977f4b518",
-            identifier: {
-              id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518"
-            },
-            display: "John Taylor(Identifier:10010W)"
-          },
-          note: [
-            {
-              text:
-                "The patient is having a difficulty while using this medication"
-            }
-          ],
-          reaction: [
-            {
-              manifestation: [
-                {
-                  coding: [
-                    {
-                      system: "http://www.semantichealth.org/pubdoc.html",
-                      code: "10005487"
-                    },
-                    {
-                      system: "http://www.pih.org/",
-                      code: "998"
-                    },
-                    {
-                      system: "http://ciel.org",
-                      code: "148888"
-                    },
-                    {
-                      system: "http://snomed.info/sct",
-                      code: "39579001"
-                    },
-                    {
-                      system: "https://www.e-imo.com/releases/problem-it",
-                      code: "37966"
-                    },
-                    {
-                      system: "http://hl7.org/fhir/sid/icd-10",
-                      code: "T78.2"
-                    },
-                    {
-                      system:
-                        "http://www.who.int/classifications/icd/adaptations/icpc2/en/",
-                      code: "A92"
-                    },
-                    {
-                      system: "http://openmrs.org",
-                      code: "148888AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      display: "Anaphylaxis"
-                    }
-                  ],
-                  text: "Anaphylaxis"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        fullUrl: `http://localhost:8080/openmrs${fhirBaseUrl}/AllergyIntolerance/981662c2-f861-4e60-ae22-45af8ce13069`,
-        resource: {
-          resourceType: "AllergyIntolerance",
-          id: "981662c2-f861-4e60-ae22-45af8ce13069",
-          extension: [
-            {
-              url:
-                "http://fhir-es.transcendinsights.com/stu3/StructureDefinition/resource-date-created",
-              valueDateTime: "2019-11-11T18:41:27+00:00"
-            },
-            {
-              url:
-                "https://purl.org/elab/fhir/StructureDefinition/Creator-crew-version1",
-              valueString: "doc"
-            },
-            {
-              url: "dateChanged",
-              valueDateTime: "2019-11-12T06:53:15+00:00"
-            }
-          ],
-          category: ["medication"],
-          criticality: "high",
-          code: {
-            coding: [
-              {
-                system: "http://snomed.info/sct",
-                code: "96308008"
-              },
-              {
-                system: "med-rt nui",
-                code: "N0000175561"
-              },
-              {
-                system: "http://ciel.org",
-                code: "162299"
-              },
-              {
-                system:
-                  "http://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/NDFRT/",
-                code: "N0000175561"
-              },
-              {
-                system: "http://openmrs.org",
-                code: "162299AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                display: "ARBs (angiotensin II receptor blockers)"
-              }
-            ],
-            text: "ARBs (angiotensin II receptor blockers)"
-          },
-          patient: {
-            id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518",
-            reference: "Patient/90f7f0b4-06a8-4a97-9678-e7a977f4b518",
-            identifier: {
-              id: "90f7f0b4-06a8-4a97-9678-e7a977f4b518"
-            },
-            display: "John Taylor(Identifier:10010W)"
-          },
-          note: [
-            {
-              text:
-                "The patient had to be rushed to the emergency room after suffering from this reaction"
-            }
-          ],
-          reaction: [
-            {
-              manifestation: [
-                {
-                  text: "Hepatotoxicity"
-                },
-                {
-                  text: "Rash"
-                }
-              ]
-            }
-          ]
-        }
-      }
-    ]
-  }
-};
+jest.mock("../shared-utils", () => ({
+  openWorkspaceTab: jest.fn()
+}));
 
-const patient: fhir.Patient = {
-  resourceType: "Patient",
-  id: "8673ee4f-e2ab-4077-ba55-4980f408773e",
-  extension: [
-    {
-      url:
-        "http://fhir-es.transcendinsights.com/stu3/StructureDefinition/resource-date-created",
-      valueDateTime: "2017-01-18T09:42:40+00:00"
-    },
-    {
-      url:
-        "https://purl.org/elab/fhir/StructureDefinition/Creator-crew-version1",
-      valueString: "daemon"
-    }
-  ],
-  identifier: [
-    {
-      id: "1f0ad7a1-430f-4397-b571-59ea654a52db",
-      use: "usual",
-      system: "OpenMRS ID",
-      value: "10010W"
-    }
-  ],
-  active: true,
-  name: [
-    {
-      id: "efdb246f-4142-4c12-a27a-9be60b9592e9",
-      use: "usual",
-      family: "Wilson",
-      given: ["John"]
-    }
-  ],
-  gender: "male",
-  birthDate: "1972-04-04",
-  deceasedBoolean: false,
-  address: [
-    {
-      id: "0c244eae-85c8-4cc9-b168-96b51f864e77",
-      use: "home",
-      line: ["Address10351"],
-      city: "City0351",
-      state: "State0351tested",
-      postalCode: "60351",
-      country: "Country0351"
-    }
-  ]
-};
-
-describe("AlleryCardLevelTwo />", () => {
-  let match: match = { params: {}, isExact: false, path: "/", url: "/" };
-  let wrapper: any;
-
-  afterEach(cleanup);
-  beforeEach(mockPerformPatientAllergySearch.mockReset);
-  beforeEach(mockUseCurrentPatient.mockReset);
-
-  it("render without dying", async () => {
+describe("AllergiesDetailedSummary />", () => {
+  beforeEach(() => {
+    mockUseCurrentPatient.mockReset;
+    mockOpenWorkspaceTab.mockReset;
+    mockPerformPatientAllergySearch.mockReset;
     mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
-    mockPerformPatientAllergySearch.mockReturnValue(
-      Promise.resolve(mockPatientAllergyResult)
-    );
-    wrapper = render(
-      <BrowserRouter>
-        <AllergiesOverviewLevelTwo />
-      </BrowserRouter>
-    );
-
-    await wait(() => {
-      expect(wrapper).toBeDefined();
-    });
   });
 
-  it("should display the patients allergy correctly", async () => {
-    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
-    mockPerformPatientAllergySearch.mockReturnValue(
-      Promise.resolve(mockPatientAllergyResult)
-    );
-    wrapper = render(
+  it("should display a detailed summary of the patient's allergy history", async () => {
+    mockPerformPatientAllergySearch.mockReturnValue(of(mockPatientAllergies));
+
+    render(
       <BrowserRouter>
-        <AllergiesOverviewLevelTwo />
+        <AllergiesDetailedSummary />
       </BrowserRouter>
     );
 
-    await wait(() => {
-      expect(wrapper.getByText("ACE inhibitors").textContent).toBeTruthy();
-      expect(wrapper.getByText("Anaphylaxis").textContent).toBeTruthy();
-    });
+    await screen.findByText("Allergies");
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+    expect(screen.getByText("ALLERGEN")).toBeInTheDocument();
+    expect(screen.getByText("SEVERITY & REACTION")).toBeInTheDocument();
+    expect(screen.getByText("SINCE")).toBeInTheDocument();
+    expect(screen.getByText("UPDATED")).toBeInTheDocument();
+    expect(screen.getByText("Cephalosporins")).toBeInTheDocument();
+    expect(screen.getByText("Angioedema")).toBeInTheDocument();
+    expect(screen.getByText("happened today")).toBeInTheDocument();
+    expect(screen.getByText("Peanuts")).toBeInTheDocument();
+    expect(screen.getByText("Anaphylaxis")).toBeInTheDocument();
+    expect(screen.getByText("ACE inhibitors")).toBeInTheDocument();
+    expect(screen.getByText("high")).toBeInTheDocument();
+    expect(screen.getByText("Severe reaction")).toBeInTheDocument();
+
+    // Clicking "Add" launches workspace tab
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(mockOpenWorkspaceTab).toHaveBeenCalled();
+    expect(mockOpenWorkspaceTab).toHaveBeenCalledWith(
+      AllergyForm,
+      "Allergies Form",
+      { allergyUuid: null }
+    );
   });
 
-  it("should not display the patients allergy when no allergy is returned", async () => {
-    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
-    mockPerformPatientAllergySearch.mockReturnValue(
-      Promise.resolve({ data: { total: 0 } })
-    );
-    wrapper = render(
+  it("renders an empty state view when allergies are absent", async () => {
+    mockPerformPatientAllergySearch.mockReturnValue(of([]));
+
+    render(
       <BrowserRouter>
-        <AllergiesOverviewLevelTwo />
+        <AllergiesDetailedSummary />
       </BrowserRouter>
     );
 
-    await wait(() => {
-      expect(
-        wrapper.getByText("The patient's allergy history is not documented.")
-          .textContent
-      ).toBeDefined();
-    });
-  });
+    await screen.findByText("Allergies");
 
-  it("should display allergies when onset date is not available", async () => {
-    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
-    mockPerformPatientAllergySearch.mockReturnValue(
-      Promise.resolve(mockPatientAllergyResultWithoutOnsetDate)
-    );
-    wrapper = render(
-      <BrowserRouter>
-        <AllergiesOverviewLevelTwo />
-      </BrowserRouter>
-    );
+    expect(screen.getByText("Allergies")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This patient has no allergy intolerances recorded in the system."
+      )
+    ).toBeInTheDocument();
 
-    await wait(() => {
-      expect(wrapper.getByText("ACE inhibitors").textContent).toBeTruthy();
-      expect(wrapper.getByText("Anaphylaxis").textContent).toBeTruthy();
-    });
+    // Clicking "Add" launches workspace tab
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(mockOpenWorkspaceTab).toHaveBeenCalled();
+    expect(mockOpenWorkspaceTab).toHaveBeenCalledWith(
+      AllergyForm,
+      "Allergies Form",
+      { allergyUuid: null }
+    );
   });
 });

--- a/src/widgets/allergies/allergies-detailed-summary.test.tsx
+++ b/src/widgets/allergies/allergies-detailed-summary.test.tsx
@@ -57,8 +57,8 @@ describe("AllergiesDetailedSummary />", () => {
     expect(screen.getByText("Peanuts")).toBeInTheDocument();
     expect(screen.getByText("Anaphylaxis")).toBeInTheDocument();
     expect(screen.getByText("ACE inhibitors")).toBeInTheDocument();
-    expect(screen.getByText("high")).toBeInTheDocument();
-    expect(screen.getByText("Severe reaction")).toBeInTheDocument();
+    expect(screen.getAllByText("high").length).toEqual(2);
+    expect(screen.getAllByText("Severe reaction").length).toEqual(2);
 
     // Clicking "Add" launches workspace tab
     fireEvent.click(screen.getByRole("button", { name: "Add" }));

--- a/src/widgets/allergies/allergies-overview.component.tsx
+++ b/src/widgets/allergies/allergies-overview.component.tsx
@@ -1,21 +1,21 @@
 import React, { useState, useEffect } from "react";
+import { capitalize } from "lodash-es";
+import { useTranslation } from "react-i18next";
+import { createErrorHandler } from "@openmrs/esm-error-handling";
+import { useCurrentPatient } from "@openmrs/esm-api";
+import { openWorkspaceTab } from "../shared-utils";
+import useChartBasePath from "../../utils/use-chart-base";
+import EmptyState from "../../ui-components/empty-state/empty-state.component";
+import HorizontalLabelValue from "../../ui-components/cards/horizontal-label-value.component";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import SummaryCardRow from "../../ui-components/cards/summary-card-row.component";
 import SummaryCardFooter from "../../ui-components/cards/summary-card-footer.component";
-import EmptyState from "../../ui-components/empty-state/empty-state.component";
 import {
   performPatientAllergySearch,
   Allergy
 } from "./allergy-intolerance.resource";
-import styles from "./allergies-overview.css";
-import HorizontalLabelValue from "../../ui-components/cards/horizontal-label-value.component";
-import { createErrorHandler } from "@openmrs/esm-error-handling";
-import { useCurrentPatient } from "@openmrs/esm-api";
 import AllergyForm from "./allergy-form.component";
-import { openWorkspaceTab } from "../shared-utils";
-import useChartBasePath from "../../utils/use-chart-base";
-import { useTranslation } from "react-i18next";
-import { capitalize } from "lodash-es";
+import styles from "./allergies-overview.css";
 
 export default function AllergiesOverview(props: AllergiesOverviewProps) {
   const initialAllergiesBatchCount = 3;
@@ -26,12 +26,7 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
     []
   );
   const [allergiesExpanded, setAllergiesExpanded] = useState<boolean>(false);
-  const [
-    isLoadingPatient,
-    patient,
-    patientUuid,
-    patientErr
-  ] = useCurrentPatient();
+  const [isLoadingPatient, patient, patientUuid] = useCurrentPatient();
   const chartBasePath = useChartBasePath();
   const allergiesPath = chartBasePath + "/" + props.basePath;
   const { t } = useTranslation();
@@ -52,7 +47,7 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
   }, [isLoadingPatient, patient]);
 
   useEffect(() => {
-    if (allPatientAllergies?.length < initialAllergiesBatchCount) {
+    if (allPatientAllergies?.length <= initialAllergiesBatchCount) {
       setAllergiesExpanded(true);
     }
   }, [allPatientAllergies]);

--- a/src/widgets/allergies/allergies-overview.component.tsx
+++ b/src/widgets/allergies/allergies-overview.component.tsx
@@ -3,21 +3,29 @@ import SummaryCard from "../../ui-components/cards/summary-card.component";
 import SummaryCardRow from "../../ui-components/cards/summary-card-row.component";
 import SummaryCardFooter from "../../ui-components/cards/summary-card-footer.component";
 import EmptyState from "../../ui-components/empty-state/empty-state.component";
-import { performPatientAllergySearch } from "./allergy-intolerance.resource";
+import {
+  performPatientAllergySearch,
+  Allergy
+} from "./allergy-intolerance.resource";
 import styles from "./allergies-overview.css";
 import HorizontalLabelValue from "../../ui-components/cards/horizontal-label-value.component";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import AllergyForm from "./allergy-form.component";
-import { openWorkspaceTab, capitalize } from "../shared-utils";
+import { openWorkspaceTab } from "../shared-utils";
 import useChartBasePath from "../../utils/use-chart-base";
 import { useTranslation } from "react-i18next";
+import { capitalize } from "lodash-es";
 
 export default function AllergiesOverview(props: AllergiesOverviewProps) {
-  const initialResultsBatch = 3;
-  const [allPatientAllergies, setAllPatientAllergies] = useState(null);
-  const [initialAllergiesBatch, setInitialAllergiesBatch] = useState([]);
-  const [allergiesExpanded, setAllergiesExpanded] = useState(false);
+  const initialAllergiesBatchCount = 3;
+  const [allPatientAllergies, setAllPatientAllergies] = useState<Allergy[]>(
+    null
+  );
+  const [initialAllergiesBatch, setInitialAllergiesBatch] = useState<Allergy[]>(
+    []
+  );
+  const [allergiesExpanded, setAllergiesExpanded] = useState<boolean>(false);
   const [
     isLoadingPatient,
     patient,
@@ -34,7 +42,9 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
         patient.identifier[0].value
       ).subscribe(allergies => {
         setAllPatientAllergies(allergies);
-        setInitialAllergiesBatch(allergies.slice(0, initialResultsBatch));
+        setInitialAllergiesBatch(
+          allergies.slice(0, initialAllergiesBatchCount)
+        );
       }, createErrorHandler());
 
       return () => sub.unsubscribe();
@@ -42,10 +52,7 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
   }, [isLoadingPatient, patient]);
 
   useEffect(() => {
-    if (
-      allPatientAllergies &&
-      allPatientAllergies.length < initialResultsBatch
-    ) {
+    if (allPatientAllergies?.length < initialAllergiesBatchCount) {
       setAllergiesExpanded(true);
     }
   }, [allPatientAllergies]);
@@ -70,7 +77,7 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
           }}
         >
           {initialAllergiesBatch.map(allergy => {
-            const manifestations = allergy?.reactionManifestations?.join(", ");
+            const manifestations = allergy.reactionManifestations?.join(", ");
             return (
               <SummaryCardRow
                 key={allergy.id}
@@ -81,7 +88,7 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
                   labelClassName="omrs-medium"
                   labelStyles={{ flex: "1" }}
                   value={`${manifestations ? manifestations : ""} (${capitalize(
-                    allergy?.reactionSeverity
+                    allergy.reactionSeverity
                   )})`}
                   valueStyles={{ flex: "1", paddingLeft: "1rem" }}
                   valueClassName={styles.allergyReaction}

--- a/src/widgets/allergies/allergies-overview.component.tsx
+++ b/src/widgets/allergies/allergies-overview.component.tsx
@@ -52,7 +52,7 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
     }
   }, [allPatientAllergies]);
 
-  const loadMoreAllergies = () => {
+  const showMoreAllergies = () => {
     setInitialAllergiesBatch(allPatientAllergies);
     setAllergiesExpanded(true);
   };
@@ -72,7 +72,8 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
           }}
         >
           {initialAllergiesBatch.map(allergy => {
-            const manifestations = allergy.reactionManifestations?.join(", ");
+            const manifestations =
+              allergy.reactionManifestations?.join(", ") || "";
             return (
               <SummaryCardRow
                 key={allergy.id}
@@ -82,7 +83,7 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
                   label={allergy.display}
                   labelClassName="omrs-medium"
                   labelStyles={{ flex: "1" }}
-                  value={`${manifestations ? manifestations : ""} (${capitalize(
+                  value={`${manifestations} (${capitalize(
                     allergy.reactionSeverity
                   )})`}
                   valueStyles={{ flex: "1", paddingLeft: "1rem" }}
@@ -101,7 +102,7 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
               >
                 <use xlinkHref="#omrs-icon-chevron-down" />
               </svg>
-              <button className="omrs-unstyled" onClick={loadMoreAllergies}>
+              <button className="omrs-unstyled" onClick={showMoreAllergies}>
                 <p className="omrs-bold">More</p>
               </button>
             </div>

--- a/src/widgets/allergies/allergies-overview.css
+++ b/src/widgets/allergies/allergies-overview.css
@@ -1,8 +1,17 @@
 .allergyReaction {
   color: var(--omrs-color-ink-medium-contrast);
-  text-transform: lowercase;
 }
 
-.allergyReaction::first-letter {
-  text-transform: capitalize;
+.allergiesFooter {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0rem 0rem 0rem 0.5rem;
+  background-color: var(--omrs-color-bg-medium-contrast);
+  margin: 0rem;
+  color: var(--omrs-color-ink-medium-contrast);
+}
+
+.allergiesFooter p {
+  padding-left: 0.5rem;
 }

--- a/src/widgets/allergies/allergies-overview.test.tsx
+++ b/src/widgets/allergies/allergies-overview.test.tsx
@@ -60,11 +60,6 @@ describe("<AllergiesOverview />", () => {
     expect(
       screen.getByText("Angioedema, Anaphylaxis (Severe)")
     ).toBeInTheDocument();
-    const moreBtn = screen.getByRole("button", { name: "More" });
-    expect(moreBtn).toBeInTheDocument();
-
-    fireEvent.click(moreBtn);
-
     expect(screen.getByText("See all")).toBeInTheDocument();
 
     // Clicking "Add" launches workspace tab

--- a/src/widgets/allergies/allergies-overview.test.tsx
+++ b/src/widgets/allergies/allergies-overview.test.tsx
@@ -60,6 +60,15 @@ describe("<AllergiesOverview />", () => {
     expect(
       screen.getByText("Angioedema, Anaphylaxis (Severe)")
     ).toBeInTheDocument();
+    const moreBtn = screen.getByRole("button", { name: "More" });
+    expect(moreBtn).toBeInTheDocument();
+
+    // Clicking more shows more allergies
+    fireEvent.click(moreBtn);
+    expect(screen.getByText("Sulfonamides")).toBeInTheDocument();
+    expect(
+      screen.getByText("Anaphylaxis, Severe blistering rash (Severe)")
+    ).toBeInTheDocument();
     expect(screen.getByText("See all")).toBeInTheDocument();
 
     // Clicking "Add" launches workspace tab

--- a/src/widgets/allergies/allergies-overview.test.tsx
+++ b/src/widgets/allergies/allergies-overview.test.tsx
@@ -1,16 +1,20 @@
 import React from "react";
-import { render, cleanup, wait } from "@testing-library/react";
-import AllergiesOverview from "./allergies-overview.component";
 import { BrowserRouter } from "react-router-dom";
-import { performPatientAllergySearch } from "./allergy-intolerance.resource";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { useCurrentPatient } from "@openmrs/esm-api";
+import { of } from "rxjs/internal/observable/of";
+import AllergiesOverview from "./allergies-overview.component";
+import AllergyForm from "./allergy-form.component";
+import { performPatientAllergySearch } from "./allergy-intolerance.resource";
 import {
   patient,
-  mockPatientAllergyResult
-} from "../../../__mocks__/allergy.mock";
+  mockPatientAllergies
+} from "../../../__mocks__/allergies.mock";
+import { openWorkspaceTab } from "../shared-utils";
 
 const mockUseCurrentPatient = useCurrentPatient as jest.Mock;
 const mockPerformPatientAllergySearch = performPatientAllergySearch as jest.Mock;
+const mockOpenWorkspaceTab = openWorkspaceTab as jest.Mock;
 
 jest.mock("./allergy-intolerance.resource", () => ({
   performPatientAllergySearch: jest.fn()
@@ -20,71 +24,84 @@ jest.mock("@openmrs/esm-api", () => ({
   useCurrentPatient: jest.fn()
 }));
 
+jest.mock("../shared-utils", () => ({
+  capitalize: jest
+    .fn()
+    .mockImplementation(s => s.charAt(0).toUpperCase() + s.slice(1)),
+  openWorkspaceTab: jest.fn()
+}));
+
 describe("<AllergiesOverview />", () => {
-  let match, wrapper: any;
-
-  afterEach(cleanup);
-
   beforeEach(() => {
-    match = { params: {}, isExact: false, path: "/", url: "/" };
-  });
-  beforeEach(() => {
+    mockUseCurrentPatient.mockReset;
+    mockOpenWorkspaceTab.mockReset;
+    mockPerformPatientAllergySearch.mockReset;
     mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
-  });
-  beforeEach(mockPerformPatientAllergySearch.mockReset);
-
-  it("render AllergiesOverview without dying", async () => {
-    mockPerformPatientAllergySearch.mockReturnValue(
-      Promise.resolve(mockPatientAllergyResult)
-    );
-
-    wrapper = render(
-      <BrowserRouter>
-        <AllergiesOverview basePath="/" />
-      </BrowserRouter>
-    );
-
-    await wait(() => {
-      expect(wrapper).toBeDefined();
-    });
-  });
-
-  it("renders an empty state view when allergies are absent", async () => {
-    mockPerformPatientAllergySearch.mockReturnValue(Promise.resolve([]));
-
-    wrapper = render(
-      <BrowserRouter>
-        <AllergiesOverview basePath="/" />
-      </BrowserRouter>
-    );
-
-    await wait(() => {
-      expect(wrapper).toBeDefined();
-      expect(wrapper.getByText("Add").textContent).toBeTruthy();
-      expect(wrapper.getByText("Allergies").textContent).toBeTruthy();
-      expect(
-        wrapper.getByText(
-          "This patient has no allergy intolerances recorded in the system."
-        ).textContent
-      ).toBeTruthy();
-    });
   });
 
   it("should display the patient's allergic reactions and their manifestations", async () => {
-    mockPerformPatientAllergySearch.mockReturnValue(
-      Promise.resolve(mockPatientAllergyResult)
-    );
-    wrapper = render(
+    mockPerformPatientAllergySearch.mockReturnValue(of(mockPatientAllergies));
+
+    render(
       <BrowserRouter>
         <AllergiesOverview basePath="/" />
       </BrowserRouter>
     );
 
-    await wait(() => {
-      expect(wrapper.getByText("Allergies")).toBeTruthy();
-      expect(wrapper.getByText("Add")).toBeTruthy();
-      expect(wrapper.getByText("ACE inhibitors")).toBeTruthy();
-      expect(wrapper.getByText("AMOEBIASIS (—)")).toBeTruthy();
-    });
+    await screen.findByText("Allergies");
+
+    expect(screen.getByText("Allergies")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+    expect(screen.getByText("Cephalosporins")).toBeInTheDocument();
+    expect(screen.getByText("Angioedema (Severe)")).toBeInTheDocument();
+    expect(screen.getByText("Peanuts")).toBeInTheDocument();
+    expect(screen.getByText("Anaphylaxis (Mild)")).toBeInTheDocument();
+    expect(screen.getByText("ACE inhibitors")).toBeInTheDocument();
+    expect(
+      screen.getByText("Angioedema, Anaphylaxis (Severe)")
+    ).toBeInTheDocument();
+    const moreBtn = screen.getByRole("button", { name: "More" });
+    expect(moreBtn).toBeInTheDocument();
+
+    fireEvent.click(moreBtn);
+
+    expect(screen.getByText("See all")).toBeInTheDocument();
+
+    // Clicking "Add" launches workspace tab
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(mockOpenWorkspaceTab).toHaveBeenCalled();
+    expect(mockOpenWorkspaceTab).toHaveBeenCalledWith(
+      AllergyForm,
+      "Allergies Form",
+      { allergyUuid: null }
+    );
+  });
+
+  it("renders an empty state view when allergies are absent", async () => {
+    mockPerformPatientAllergySearch.mockReturnValue(of([]));
+
+    render(
+      <BrowserRouter>
+        <AllergiesOverview basePath="/" />
+      </BrowserRouter>
+    );
+
+    await screen.findByText("Allergies");
+
+    expect(screen.getByText("Allergies")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This patient has no allergy intolerances recorded in the system."
+      )
+    ).toBeInTheDocument();
+
+    // Clicking "Add" launches workspace tab
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(mockOpenWorkspaceTab).toHaveBeenCalled();
+    expect(mockOpenWorkspaceTab).toHaveBeenCalledWith(
+      AllergyForm,
+      "Allergies Form"
+    );
   });
 });

--- a/src/widgets/allergies/allergy-form.component.tsx
+++ b/src/widgets/allergies/allergy-form.component.tsx
@@ -248,7 +248,7 @@ export default function AllergyForm(props: AllergyFormProps) {
     }
   };
 
-  function createForm() {
+  function createAllergy() {
     return (
       <SummaryCard
         name="Add New Allergy"
@@ -477,7 +477,7 @@ export default function AllergyForm(props: AllergyFormProps) {
     );
   }
 
-  function editForm() {
+  function editAllergy() {
     return (
       <SummaryCard
         name="Edit Allergy"
@@ -671,7 +671,7 @@ export default function AllergyForm(props: AllergyFormProps) {
 
   return (
     <div className={styles.allergyForm}>
-      {viewEditForm ? editForm() : createForm()}
+      {viewEditForm ? editAllergy() : createAllergy()}
     </div>
   );
 }

--- a/src/widgets/allergies/allergy-form.component.tsx
+++ b/src/widgets/allergies/allergy-form.component.tsx
@@ -314,7 +314,7 @@ export default function AllergyForm(props: AllergyFormProps) {
                   value="noAllergy"
                   onChange={handleAllergenChange}
                 />
-                <span>Patient has no allergies</span>
+                <span>Patient has no known allergies</span>
               </label>
             </div>
           </div>

--- a/src/widgets/allergies/allergy-form.component.tsx
+++ b/src/widgets/allergies/allergy-form.component.tsx
@@ -24,9 +24,9 @@ export default function AllergyForm(props: AllergyFormProps) {
   const [allergicReactions, setAllergicReactions] = useState<
     Array<AllergicReaction>
   >([]);
-  const [selectedAllergicReactions, setSelectedAllergicReactions] = useState(
-    []
-  );
+  const [selectedAllergicReactions, setSelectedAllergicReactions] = useState<
+    SelectedAllergicReaction[]
+  >([]);
   const [codedAllergenUuid, setCodedAllergenUuid] = useState<string>(null);
   const [allergenType, setAllergenType] = useState("");
   const [allergensArray, setAllergensArray] = useState<Array<Allergen>>(null);
@@ -41,13 +41,8 @@ export default function AllergyForm(props: AllergyFormProps) {
     null
   );
   const [allergyComment, setAllergyComment] = useState<string>(null);
-  const [updatedDate, setUpdatedDate] = useState<string>(null);
-  const [
-    isLoadingPatient,
-    patient,
-    patientUuid,
-    patientErr
-  ] = useCurrentPatient();
+  const [, setUpdatedDate] = useState<string>(null);
+  const [isLoadingPatient, , patientUuid] = useCurrentPatient();
   const [formChanged, setFormChanged] = useState(false);
   const history = useHistory();
 
@@ -137,17 +132,17 @@ export default function AllergyForm(props: AllergyFormProps) {
   const handleAllergicReactionChange = (
     event: SyntheticEvent<HTMLInputElement, Event>
   ) => {
-    if (event.currentTarget.checked === true) {
-      // upon selecting a reaction
-      selectedAllergicReactions.push({ uuid: event.currentTarget.value });
-      setSelectedAllergicReactions(selectedAllergicReactions);
-    } else {
-      // upon deselecting a reaction
-      const modifiedAllergicReactions = selectedAllergicReactions.filter(
-        rxn => rxn.uuid !== event.currentTarget.value
-      );
-      setSelectedAllergicReactions(modifiedAllergicReactions);
-    }
+    const eventTarget = event.currentTarget;
+    setSelectedAllergicReactions((reactions: SelectedAllergicReaction[]) => {
+      if (eventTarget.checked === true) {
+        reactions.push({ uuid: eventTarget.value });
+        return reactions;
+      } else {
+        return reactions.filter(
+          reaction => reaction.uuid !== eventTarget.value
+        );
+      }
+    });
   };
 
   const handleCreateFormSubmit = (event: SyntheticEvent<HTMLFormElement>) => {

--- a/src/widgets/allergies/allergy-form.component.tsx
+++ b/src/widgets/allergies/allergy-form.component.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { useHistory, match } from "react-router-dom";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
-import style from "./allergy-form.css";
+import styles from "./allergy-form.css";
 import {
   getAllergyAllergenByConceptUuid,
-  getAllergyReaction,
+  getAllergicReactions,
   savePatientAllergy,
   deletePatientAllergy,
   getPatientAllergyByPatientUuid,
@@ -13,183 +13,160 @@ import {
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import dayjs from "dayjs";
-import { DataCaptureComponentProps } from "../shared-utils";
-
-const DRUG_ALLERGEN_CONCEPT: string = "162552AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-const ENVIRONMENTAL_ALLERGEN_CONCEPT: string =
-  "162554AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-const FOOD_ALLERGEN_CONCEPT: string = "162553AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-const MILD_REACTION_SEVERITY_CONCEPT: string =
-  "1498AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-const MODERATE_REACTION_SEVERITY_CONCEPT: string =
-  "1499AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-const SEVERE_REACTION_SEVERITY_CONCEPT: string =
-  "1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+import { DataCaptureComponentProps, capitalize } from "../shared-utils";
 
 export default function AllergyForm(props: AllergyFormProps) {
-  const [codedAllergenUuid, setCodedAllergenUuid] = React.useState(null);
-  const [allergenType, setAllergenType] = React.useState(null);
-  const [allergensArray, setAllergensArray] = React.useState(null);
-  const [allergyReaction, setAllergyReaction] = React.useState(null);
-  const [enableCreateButtons, setEnableCreateButtons] = React.useState(true);
-  const [enableEditButtons, setEnableEditButtons] = React.useState(true);
-  const [patientAlleryReaction, setPatientAllergyReaction] = React.useState([]);
-  const [comment, setComment] = React.useState("");
-  const [selectedAllergyCategory, setSelectedAllergyCategory] = React.useState(
-    null
+  const formRef = useRef<HTMLFormElement>(null);
+  const [viewEditForm, setViewEditForm] = useState(false);
+  const [patientAllergy, setPatientAllergy] = useState(null);
+  const [allergicReactions, setAllergicReactions] = useState([]);
+  const [selectedAllergicReactions, setSelectedAllergicReactions] = useState(
+    []
   );
-  const [patientAllergy, setPatientAllergy] = React.useState(null);
-  const [reactionSeverityUuid, setReactionSeverityUuid] = React.useState(null);
-  const [allergyComment, setAllergyComment] = React.useState(null);
-  const [updatedDate, setUpdatedDate] = React.useState(null);
+  const [codedAllergenUuid, setCodedAllergenUuid] = useState(null);
+  const [allergenType, setAllergenType] = useState(null);
+  const [allergensArray, setAllergensArray] = useState(null);
+  const [firstOnsetDate, setFirstOnsetDate] = useState(null);
+  const [enableCreateButtons, setEnableCreateButtons] = useState(true);
+  const [enableEditButtons, setEnableEditButtons] = useState(true);
+  const [comment, setComment] = useState("");
+  const [selectedAllergyCategory, setSelectedAllergyCategory] = useState(null);
+  const [reactionSeverityUuid, setReactionSeverityUuid] = useState(null);
+  const [allergyComment, setAllergyComment] = useState(null);
+  const [updatedDate, setUpdatedDate] = useState(null);
   const [
     isLoadingPatient,
     patient,
     patientUuid,
     patientErr
   ] = useCurrentPatient();
-  const formRef = React.useRef<HTMLFormElement>(null);
-  const [viewForm, setViewForm] = React.useState(true);
-  const [formChanged, setFormChanged] = React.useState<boolean>();
-
-  const handleAllergenChange = event => {
-    setAllergensArray(null);
-    setAllergenType(getAllergenType(event.target.value));
-    setSelectedAllergyCategory(event.target.value);
-  };
-
+  const [formChanged, setFormChanged] = useState<boolean>(false);
   let history = useHistory();
 
-  function getAllergenType(allergenConcept: string): string {
-    switch (allergenConcept) {
-      case DRUG_ALLERGEN_CONCEPT:
-        return "DRUG";
-      case FOOD_ALLERGEN_CONCEPT:
-        return "FOOD";
-      case ENVIRONMENTAL_ALLERGEN_CONCEPT:
-        return "ENVIRONMENT";
-      default:
-        "NO ALLERGEN";
+  useEffect(() => {
+    if (props.match.params["allergyUuid"]) {
+      setViewEditForm(true);
     }
-  }
+  }, [props.match.params]);
 
-  React.useEffect(() => {
-    if (
-      comment &&
-      allergenType &&
-      codedAllergenUuid &&
-      patientAlleryReaction &&
-      reactionSeverityUuid
-    ) {
-      setEnableCreateButtons(false);
-    } else {
-      setEnableCreateButtons(true);
-    }
-  }, [
-    comment,
-    allergenType,
-    codedAllergenUuid,
-    patientAlleryReaction,
-    reactionSeverityUuid
-  ]);
-
-  React.useEffect(() => {
-    if (
-      updatedDate &&
-      reactionSeverityUuid &&
-      allergyComment &&
-      patientAlleryReaction.length > 0
-    ) {
-      setEnableEditButtons(false);
-    } else {
-      setEnableEditButtons(true);
-    }
-  }, [
-    updatedDate,
-    reactionSeverityUuid,
-    allergyComment,
-    patientAlleryReaction
-  ]);
-
-  React.useEffect(() => {
-    if (patientAllergy) {
-      setAllergyComment(patientAllergy.comment);
-      setReactionSeverityUuid(patientAllergy.severity.uuid);
-      setUpdatedDate(patientAllergy.auditInfo.dateCreated);
-      setPatientAllergyReaction(
-        patientAllergy.reactions.map(reaction => {
-          return { uuid: reaction.reaction.uuid };
-        })
-      );
-    }
-  }, [patientAllergy]);
-
-  React.useEffect(() => {
+  useEffect(() => {
     const abortController = new AbortController();
-    if (patientUuid && !isLoadingPatient && props.match.params) {
+    if (patientUuid && !isLoadingPatient && viewEditForm) {
       getPatientAllergyByPatientUuid(
         patientUuid,
         props.match.params,
         abortController
       )
         .then(response => setPatientAllergy(response.data))
-        .catch(createErrorHandler);
+        .catch(createErrorHandler());
 
       return () => abortController.abort();
     }
-  }, [patientUuid, isLoadingPatient, props.match.params]);
+  }, [patientUuid, isLoadingPatient, viewEditForm, props.match.params]);
 
-  React.useEffect(() => {
-    if (patientUuid && !isLoadingPatient) {
-      const subscription = getAllergyReaction().subscribe(
-        data => setAllergyReaction(data),
+  useEffect(() => {
+    if (viewEditForm && patientAllergy) {
+      setAllergyComment(patientAllergy?.comment);
+      setReactionSeverityUuid(patientAllergy?.severity?.uuid);
+      setUpdatedDate(patientAllergy?.auditInfo?.dateCreated);
+      setSelectedAllergicReactions(
+        patientAllergy?.reactions?.map(reaction => {
+          return {
+            display: reaction?.reaction?.display,
+            uuid: reaction?.reaction?.uuid
+          };
+        })
+      );
+    }
+  }, [viewEditForm, patientAllergy]);
+
+  useEffect(() => {
+    if (viewEditForm) {
+      const getAllergicReactionsSub = getAllergicReactions().subscribe(
+        allergicReactions => {
+          setAllergicReactions(allergicReactions);
+        },
         createErrorHandler()
       );
-
-      return () => subscription.unsubscribe();
-    }
-  }, [patientUuid, isLoadingPatient]);
-
-  React.useEffect(() => {
-    if (selectedAllergyCategory) {
-      const sub1 = getAllergyAllergenByConceptUuid(
-        selectedAllergyCategory
-      ).subscribe(data => setAllergensArray(data), createErrorHandler);
-      const sub2 = getAllergyReaction().subscribe(
-        data => setAllergyReaction(data),
-        createErrorHandler
-      );
       return () => {
-        sub1.unsubscribe();
-        sub2.unsubscribe();
+        getAllergicReactionsSub.unsubscribe();
       };
     }
-  }, [selectedAllergyCategory]);
+  }, [viewEditForm]);
 
-  const handleAllergenReactionChange = event => {
-    if (event.target.checked == true) {
-      setPatientAllergyReaction([
-        ...patientAlleryReaction,
-        { uuid: event.target.value }
-      ]);
+  useEffect(() => {
+    // allergenType is a required field in the Create form
+    if (!viewEditForm && allergenType) {
+      setEnableCreateButtons(true);
     } else {
-      patientAlleryReaction.splice(
-        patientAlleryReaction.findIndex(
-          reaction => reaction.uuid == event.target.value
-        ),
-        1
-      );
+      setEnableCreateButtons(false);
     }
+  }, [allergenType, firstOnsetDate, viewEditForm]);
+
+  useEffect(() => {
+    if (viewEditForm && formChanged) {
+      setEnableEditButtons(true);
+    } else {
+      setEnableEditButtons(false);
+    }
+  }, [formChanged, viewEditForm]);
+
+  useEffect(() => {
+    if (selectedAllergyCategory && !viewEditForm) {
+      const getAllergensSub = getAllergyAllergenByConceptUuid(
+        selectedAllergyCategory
+      ).subscribe(data => setAllergensArray(data), createErrorHandler());
+      const getAllergicReactionsSub = getAllergicReactions().subscribe(
+        data => setAllergicReactions(data),
+        createErrorHandler()
+      );
+      return () => {
+        getAllergensSub.unsubscribe();
+        getAllergicReactionsSub.unsubscribe();
+      };
+    }
+  }, [selectedAllergyCategory, viewEditForm]);
+
+  const handleAllergicReactionChange = event => {
+    if (event.target.checked === true) {
+      // upon selecting a reaction
+      selectedAllergicReactions.push({ uuid: event.target.value });
+      setSelectedAllergicReactions(selectedAllergicReactions);
+    } else {
+      // upon deselecting a reaction
+      const modifiedAllergicReactions = selectedAllergicReactions.filter(
+        rxn => rxn.uuid !== event.target.value
+      );
+      setSelectedAllergicReactions(modifiedAllergicReactions);
+    }
+  };
+
+  const handleCreateFormSubmit = event => {
+    event.preventDefault();
+    const patientAllergy: AllergyData = {
+      allergenType: allergenType,
+      codedAllergenUuid: codedAllergenUuid,
+      severityUuid: reactionSeverityUuid,
+      comment: comment,
+      reactionUuids: selectedAllergicReactions
+    };
+    const abortController = new AbortController();
+    savePatientAllergy(patientAllergy, patientUuid, abortController)
+      .then(response => {
+        response.status === 201 && navigate();
+      })
+      .catch(createErrorHandler());
+    return () => abortController.abort();
   };
 
   const handleEditFormSubmit = event => {
     event.preventDefault();
-    const allergy: Allergy = {
-      allergenType: patientAllergy.allergen.allergenType,
-      codedAllergenUuid: patientAllergy.allergen.codedAllergen.uuid,
+    const allergy: AllergyData = {
+      allergenType: patientAllergy?.allergen?.allergenType,
+      codedAllergenUuid: patientAllergy?.allergen?.codedAllergen?.uuid,
       severityUuid: reactionSeverityUuid,
       comment: allergyComment,
-      reactionsUuid: patientAlleryReaction
+      reactionUuids: selectedAllergicReactions
     };
     const abortController = new AbortController();
     updatePatientAllergy(
@@ -198,26 +175,8 @@ export default function AllergyForm(props: AllergyFormProps) {
       props.match.params,
       abortController
     ).then(response => {
-      response.status == 200 && navigate();
+      response.status === 200 && navigate();
     }, createErrorHandler);
-    return () => abortController.abort();
-  };
-
-  const handleCreateFormSubmit = event => {
-    event.preventDefault();
-    const patientAllergy: Allergy = {
-      allergenType: allergenType,
-      codedAllergenUuid: codedAllergenUuid,
-      severityUuid: reactionSeverityUuid,
-      comment: comment,
-      reactionsUuid: patientAlleryReaction
-    };
-    const abortController = new AbortController();
-    savePatientAllergy(patientAllergy, patientUuid, abortController)
-      .then(response => {
-        response.status == 201 && navigate();
-      })
-      .catch(createErrorHandler());
     return () => abortController.abort();
   };
 
@@ -227,8 +186,8 @@ export default function AllergyForm(props: AllergyFormProps) {
   }
 
   const setCheckedValue = uuid => {
-    return patientAllergy.reactions.some(
-      reaction => reaction.reaction.uuid === uuid
+    return patientAllergy?.reactions?.some(
+      reaction => reaction?.reaction?.uuid === uuid
     );
   };
 
@@ -236,12 +195,31 @@ export default function AllergyForm(props: AllergyFormProps) {
     const abortController = new AbortController();
     deletePatientAllergy(patientUuid, props.match.params, abortController).then(
       response => {
-        response.status == 204 && navigate();
+        response.status === 204 && navigate();
       }
     );
   };
 
-  const closeForm = () => {
+  const getAllergyType = (allergyConcept: string): string => {
+    switch (allergyConcept) {
+      case AllergyConcepts.DRUG_ALLERGEN:
+        return "DRUG";
+      case AllergyConcepts.FOOD_ALLERGEN:
+        return "FOOD";
+      case AllergyConcepts.ENVIRONMENTAL_ALLERGEN:
+        return "ENVIRONMENT";
+      default:
+        "NO ALLERGEN";
+    }
+  };
+
+  const handleAllergenChange = event => {
+    setAllergensArray(null);
+    setAllergenType(getAllergyType(event.target.value));
+    setSelectedAllergyCategory(event.target.value);
+  };
+
+  const closeForm = event => {
     formRef.current.reset();
     let userConfirmed: boolean = false;
     if (formChanged) {
@@ -262,120 +240,119 @@ export default function AllergyForm(props: AllergyFormProps) {
   function createForm() {
     return (
       <SummaryCard
-        name="Add Allergy"
+        name="Add New Allergy"
         styles={{
           width: "100%",
           background: "var(--omrs-color-bg-medium-contrast)"
         }}
       >
         <form
+          ref={formRef}
           onSubmit={handleCreateFormSubmit}
           onChange={() => {
             setFormChanged(true);
             return props.entryStarted();
           }}
-          ref={formRef}
         >
-          <h4 className={`${style.allergyHeader} omrs-bold`}>
+          <h4 className={`${styles.allergyHeader} omrs-bold`}>
             Category of reaction
           </h4>
-          <div className={`${style.container}`}>
-            <div className={`omrs-radio-button ${style.inputMargin}`}>
+          <div className={`${styles.container}`}>
+            <div className="omrs-radio-button">
               <label>
                 <input
+                  id={AllergyConcepts.DRUG_ALLERGEN}
                   type="radio"
                   name="allergenType"
-                  value={DRUG_ALLERGEN_CONCEPT}
+                  value={AllergyConcepts.DRUG_ALLERGEN}
                   onChange={handleAllergenChange}
                 />
-                <span id="DRUG">Drug</span>
+                <span>Drug</span>
               </label>
             </div>
-            <div className={`omrs-radio-button ${style.inputMargin}`}>
+            <div className="omrs-radio-button">
               <label>
                 <input
+                  id={AllergyConcepts.FOOD_ALLERGEN}
                   type="radio"
                   name="allergenType"
-                  value={FOOD_ALLERGEN_CONCEPT}
+                  value={AllergyConcepts.FOOD_ALLERGEN}
                   onChange={handleAllergenChange}
                 />
-                <span id="FOOD">Food</span>
+                <span>Food</span>
               </label>
             </div>
-            <div className={`omrs-radio-button ${style.inputMargin}`}>
+            <div className="omrs-radio-button">
               <label>
                 <input
+                  id={AllergyConcepts.ENVIRONMENTAL_ALLERGEN}
                   type="radio"
                   name="allergenType"
-                  value={ENVIRONMENTAL_ALLERGEN_CONCEPT}
+                  value={AllergyConcepts.ENVIRONMENTAL_ALLERGEN}
                   onChange={handleAllergenChange}
                 />
-                <span id="ENVIRONMENTAL">Environmental</span>
+                <span>Environmental</span>
               </label>
             </div>
-            <div className={`omrs-radio-button ${style.inputMargin}`}>
+            <div className="omrs-radio-button">
               <label>
                 <input
+                  id="no-allergies"
                   type="radio"
                   name="allergenType"
                   value="noAllergy"
                   onChange={handleAllergenChange}
                 />
-                <span id="NOALLERGIES">Patient has no allergies</span>
+                <span>Patient has no allergies</span>
               </label>
             </div>
           </div>
           {allergensArray && (
             <div>
-              <h4 className={`${style.allergyHeader} omrs-bold`}>
-                {getAllergenType(selectedAllergyCategory)
-                  .charAt(0)
-                  .toUpperCase() +
-                  getAllergenType(selectedAllergyCategory)
-                    .slice(1)
-                    .toLowerCase()}{" "}
+              <h4 className={`${styles.allergyHeader} omrs-bold`}>
+                {capitalize(
+                  getAllergyType(selectedAllergyCategory)?.toLowerCase()
+                )}{" "}
                 allergen
               </h4>
-              <div className={style.container}>
-                {allergensArray.map(allergen => (
-                  <div
-                    className={`omrs-radio-button ${style.inputMargin}`}
-                    key={allergen.name.uuid}
-                  >
+              <div className={styles.container}>
+                {allergensArray.map((allergen, index) => (
+                  <div className="omrs-radio-button" key={index}>
                     <label>
                       <input
+                        id={allergen?.uuid}
                         type="radio"
-                        name="codedAllergenUuid"
-                        value={allergen.uuid}
+                        name="allergen-name"
+                        checked={codedAllergenUuid === allergen?.uuid}
+                        value={allergen?.uuid}
                         onChange={evt => setCodedAllergenUuid(evt.target.value)}
+                        required
                       />
-                      <span>{allergen.name.display}</span>
+                      <span>{allergen?.name?.display}</span>
                     </label>
                   </div>
                 ))}
               </div>
             </div>
           )}
-          {allergensArray && allergyReaction && (
+          {allergensArray && allergicReactions && (
             <div>
-              <h4 className={`${style.allergyHeader} omrs-bold`}>Reactions</h4>
-              <h4 className={`${style.allergyHeader} omrs-type-body-regular`}>
+              <h4 className={`${styles.allergyHeader} omrs-bold`}>Reactions</h4>
+              <h4 className={`${styles.allergyHeader} omrs-type-body-regular`}>
                 Select all that apply
               </h4>
-              <div className={style.container}>
-                {allergyReaction.map(reaction => (
-                  <div
-                    className={`omrs-checkbox ${style.inputMargin}`}
-                    key={reaction.name.uuid}
-                  >
+              <div className={styles.container}>
+                {allergicReactions.map((reaction, index) => (
+                  <div className="omrs-checkbox" key={index}>
                     <label>
                       <input
+                        id="allergen-reaction"
                         type="checkbox"
-                        name="reactionsUuid"
+                        name="reactionUuid"
                         value={reaction.uuid}
-                        onChange={handleAllergenReactionChange}
+                        onChange={handleAllergicReactionChange}
                       />
-                      <span>{reaction.name.display}</span>
+                      <span>{reaction?.name?.display}</span>
                     </label>
                   </div>
                 ))}
@@ -384,16 +361,16 @@ export default function AllergyForm(props: AllergyFormProps) {
           )}
           {allergensArray && (
             <div>
-              <h4 className={`${style.allergyHeader} omrs-bold`}>
+              <h4 className={`${styles.allergyHeader} omrs-bold`}>
                 Severity of worst reaction
               </h4>
-              <div className={`${style.container}`}>
-                <div className={`omrs-radio-button ${style.inputMargin}`}>
+              <div className={styles.container}>
+                <div className="omrs-radio-button">
                   <label>
                     <input
                       type="radio"
                       name="reactionSeverity"
-                      value={MILD_REACTION_SEVERITY_CONCEPT}
+                      value={AllergyConcepts.MILD_REACTION_SEVERITY}
                       onChange={evt =>
                         setReactionSeverityUuid(evt.target.value)
                       }
@@ -401,12 +378,12 @@ export default function AllergyForm(props: AllergyFormProps) {
                     <span>Mild</span>
                   </label>
                 </div>
-                <div className={`omrs-radio-button ${style.inputMargin}`}>
+                <div className="omrs-radio-button">
                   <label>
                     <input
                       type="radio"
                       name="reactionSeverity"
-                      value={MODERATE_REACTION_SEVERITY_CONCEPT}
+                      value={AllergyConcepts.MODERATE_REACTION_SEVERITY}
                       onChange={evt =>
                         setReactionSeverityUuid(evt.target.value)
                       }
@@ -414,12 +391,12 @@ export default function AllergyForm(props: AllergyFormProps) {
                     <span>Moderate</span>
                   </label>
                 </div>
-                <div className={`omrs-radio-button ${style.inputMargin}`}>
+                <div className="omrs-radio-button">
                   <label>
                     <input
                       type="radio"
                       name="reactionSeverity"
-                      value={SEVERE_REACTION_SEVERITY_CONCEPT}
+                      value={AllergyConcepts.SEVERE_REACTION_SEVERITY}
                       onChange={evt =>
                         setReactionSeverityUuid(evt.target.value)
                       }
@@ -428,23 +405,26 @@ export default function AllergyForm(props: AllergyFormProps) {
                   </label>
                 </div>
               </div>
-              <h4 className={`${style.allergyHeader} omrs-bold`}>
+              <h4 className={`${styles.allergyHeader} omrs-bold`}>
                 Date of first onset
               </h4>
-              <div className={`${style.container}`}>
+              <div className={styles.container}>
                 <div className="omrs-datepicker">
-                  <input type="date" name="firstDateOfOnset" required />
+                  <input
+                    id="first-onset-date"
+                    type="date"
+                    name="firstOnsetDate"
+                    onChange={evt => setFirstOnsetDate(evt.target.value)}
+                  />
                   <svg className="omrs-icon" role="img">
                     <use xlinkHref="#omrs-icon-calendar"></use>
                   </svg>
                 </div>
               </div>
-
-              <h4 className={`${style.allergyHeader} omrs-bold`}>Comments</h4>
-              <div className={style.allergyCommentContainer}>
+              <h4 className={`${styles.allergyHeader} omrs-bold`}>Comments</h4>
+              <div className={styles.allergyCommentContainer}>
                 <textarea
-                  className={`${style.allergyCommentTextArea} omrs-type-body-regular`}
-                  required
+                  className={`${styles.allergyCommentTextArea} omrs-type-body-regular`}
                   name="comment"
                   rows={6}
                   onChange={evt => setComment(evt.target.value)}
@@ -455,8 +435,8 @@ export default function AllergyForm(props: AllergyFormProps) {
           <div
             className={
               enableCreateButtons
-                ? style.buttonStyles
-                : `${style.buttonStyles} ${style.buttonStylesBorder}`
+                ? styles.buttonStyles
+                : `${styles.buttonStyles} ${styles.buttonStylesBorder}`
             }
             style={{ position: "sticky" }}
           >
@@ -470,13 +450,13 @@ export default function AllergyForm(props: AllergyFormProps) {
             </button>
             <button
               type="submit"
+              style={{ width: "50%" }}
               className={
                 enableCreateButtons
-                  ? "omrs-btn omrs-outlined omrs-rounded"
-                  : "omrs-btn omrs-filled-action omrs-rounded"
+                  ? "omrs-btn omrs-filled-action omrs-rounded"
+                  : "omrs-btn omrs-outlined omrs-rounded"
               }
-              disabled={enableCreateButtons}
-              style={{ width: "50%" }}
+              disabled={!enableCreateButtons}
             >
               Sign & Save
             </button>
@@ -495,7 +475,7 @@ export default function AllergyForm(props: AllergyFormProps) {
           background: "var(--omrs-color-bg-medium-contrast)"
         }}
       >
-        {patientAllergy && allergyReaction && (
+        {patientAllergy && allergicReactions.length && (
           <form
             ref={formRef}
             onSubmit={handleEditFormSubmit}
@@ -506,57 +486,56 @@ export default function AllergyForm(props: AllergyFormProps) {
           >
             <div>
               <div
-                className={`${style.allergyEditHeader} omrs-padding-bottom-28`}
+                className={`${styles.allergyEditHeader} omrs-padding-bottom-28`}
               >
                 <h4>Allergen</h4>
                 <h3>
-                  {patientAllergy.allergen.codedAllergen.display}{" "}
+                  {patientAllergy?.allergen?.codedAllergen?.display}{" "}
                   <span>
-                    ({patientAllergy.allergen.allergenType.toLowerCase()})
+                    ({patientAllergy?.allergen?.allergenType?.toLowerCase()})
                   </span>
                 </h3>
               </div>
               <div>
-                <h4 className={`${style.allergyHeader} omrs-bold`}>
+                <h4 className={`${styles.allergyHeader} omrs-bold`}>
                   Reactions
                 </h4>
-                <h4 className={`${style.allergyHeader} omrs-type-body-regular`}>
+                <h4
+                  className={`${styles.allergyHeader} omrs-type-body-regular`}
+                >
                   Select all that apply
                 </h4>
-                <div className={style.container}>
-                  {allergyReaction.map((reaction, index) => (
-                    <div
-                      className={`omrs-checkbox ${style.inputMargin}`}
-                      key={reaction.name.uuid}
-                    >
+                <div className={styles.container}>
+                  {allergicReactions.map((reaction, index) => (
+                    <div className="omrs-checkbox" key={index}>
                       <label>
                         <input
                           type="checkbox"
-                          name="reactionsUuid"
-                          defaultValue={reaction.uuid}
-                          defaultChecked={setCheckedValue(reaction.uuid)}
-                          onChange={handleAllergenReactionChange}
+                          name="reactionUuid"
+                          defaultValue={reaction?.uuid}
+                          defaultChecked={setCheckedValue(reaction?.uuid)}
+                          onChange={handleAllergicReactionChange}
                         />
-                        <span>{reaction.name.display}</span>
+                        <span>{reaction?.display}</span>
                       </label>
                     </div>
                   ))}
                 </div>
               </div>
               <div>
-                <h4 className={`${style.allergyHeader} omrs-bold`}>
+                <h4 className={`${styles.allergyHeader} omrs-bold`}>
                   Severity of worst reaction
                 </h4>
-                <div className={`${style.container}`}>
-                  <div className={`omrs-radio-button ${style.inputMargin}`}>
+                <div className={styles.container}>
+                  <div className="omrs-radio-button">
                     <label>
                       <input
                         type="radio"
                         name="reactionSeverity"
-                        defaultValue={MILD_REACTION_SEVERITY_CONCEPT}
+                        defaultValue={AllergyConcepts.MILD_REACTION_SEVERITY}
                         defaultChecked={
-                          patientAllergy.severity.uuid ===
-                          { MILD_REACTION_SEVERITY_CONCEPT }
+                          patientAllergy?.severity?.uuid ===
+                          AllergyConcepts.MILD_REACTION_SEVERITY
                         }
                         onChange={evt =>
                           setReactionSeverityUuid(evt.target.value)
@@ -565,15 +544,17 @@ export default function AllergyForm(props: AllergyFormProps) {
                       <span>Mild</span>
                     </label>
                   </div>
-                  <div className={`omrs-radio-button ${style.inputMargin}`}>
+                  <div className="omrs-radio-button">
                     <label>
                       <input
                         type="radio"
                         name="reactionSeverity"
-                        defaultValue={MODERATE_REACTION_SEVERITY_CONCEPT}
+                        defaultValue={
+                          AllergyConcepts.MODERATE_REACTION_SEVERITY
+                        }
                         defaultChecked={
-                          patientAllergy.severity.uuid ===
-                          MODERATE_REACTION_SEVERITY_CONCEPT
+                          patientAllergy?.severity?.uuid ===
+                          AllergyConcepts.MODERATE_REACTION_SEVERITY
                         }
                         onChange={evt =>
                           setReactionSeverityUuid(evt.target.value)
@@ -582,15 +563,15 @@ export default function AllergyForm(props: AllergyFormProps) {
                       <span>Moderate</span>
                     </label>
                   </div>
-                  <div className={`omrs-radio-button ${style.inputMargin}`}>
+                  <div className="omrs-radio-button">
                     <label>
                       <input
                         type="radio"
                         name="reactionSeverity"
-                        defaultValue={SEVERE_REACTION_SEVERITY_CONCEPT}
+                        defaultValue={AllergyConcepts.SEVERE_REACTION_SEVERITY}
                         defaultChecked={
-                          patientAllergy.severity.uuid ===
-                          SEVERE_REACTION_SEVERITY_CONCEPT
+                          patientAllergy?.severity?.uuid ===
+                          AllergyConcepts.SEVERE_REACTION_SEVERITY
                         }
                         onChange={evt =>
                           setReactionSeverityUuid(evt.target.value)
@@ -600,16 +581,16 @@ export default function AllergyForm(props: AllergyFormProps) {
                     </label>
                   </div>
                 </div>
-                <h4 className={`${style.allergyHeader} omrs-bold`}>
+                <h4 className={`${styles.allergyHeader} omrs-bold`}>
                   Date of first onset
                 </h4>
-                <div className={`${style.container}`}>
+                <div className={styles.container}>
                   <div className="omrs-datepicker">
                     <input
                       type="date"
                       name="firstDateOfOnset"
                       defaultValue={dayjs(
-                        patientAllergy.auditInfo.dateCreated
+                        patientAllergy?.auditInfo?.dateCreated
                       ).format("YYYY-MM-DD")}
                       required
                       onChange={evt => setUpdatedDate(evt.target.value)}
@@ -620,14 +601,16 @@ export default function AllergyForm(props: AllergyFormProps) {
                   </div>
                 </div>
 
-                <h4 className={`${style.allergyHeader} omrs-bold`}>Comments</h4>
-                <div className={style.allergyCommentContainer}>
+                <h4 className={`${styles.allergyHeader} omrs-bold`}>
+                  Comments
+                </h4>
+                <div className={styles.allergyCommentContainer}>
                   <textarea
-                    className={`${style.allergyCommentTextArea} omrs-type-body-regular`}
+                    className={`${styles.allergyCommentTextArea} omrs-type-body-regular`}
                     required
                     name="comment"
                     rows={6}
-                    defaultValue={patientAllergy.comment}
+                    defaultValue={patientAllergy?.comment}
                     onChange={evt => setAllergyComment(evt.target.value)}
                   ></textarea>
                 </div>
@@ -636,8 +619,8 @@ export default function AllergyForm(props: AllergyFormProps) {
             <div
               className={
                 enableEditButtons
-                  ? style.buttonStyles
-                  : `${style.buttonStyles} ${style.buttonStylesBorder}`
+                  ? styles.buttonStyles
+                  : `${styles.buttonStyles} ${styles.buttonStylesBorder}`
               }
             >
               <button
@@ -660,11 +643,11 @@ export default function AllergyForm(props: AllergyFormProps) {
                 type="submit"
                 className={
                   enableEditButtons
-                    ? "omrs-btn omrs-outlined omrs-rounded"
-                    : "omrs-btn omrs-filled-action omrs-rounded"
+                    ? "omrs-btn omrs-filled-action omrs-rounded"
+                    : "omrs-btn omrs-outlined omrs-rounded"
                 }
                 style={{ width: "50%" }}
-                disabled={enableEditButtons}
+                disabled={!enableEditButtons}
               >
                 Sign & Save
               </button>
@@ -675,12 +658,9 @@ export default function AllergyForm(props: AllergyFormProps) {
     );
   }
 
-  React.useEffect(() => {
-    setViewForm(!!props.match?.params?.["allergyUuid"]);
-  }, [props.match]);
   return (
-    <div className={style.allergyForm}>
-      {viewForm ? editForm() : createForm()}
+    <div className={styles.allergyForm}>
+      {viewEditForm ? editForm() : createForm()}
     </div>
   );
 }
@@ -692,12 +672,21 @@ AllergyForm.defaultProps = {
   closeComponent: () => {}
 };
 
+enum AllergyConcepts {
+  DRUG_ALLERGEN = "162552AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  ENVIRONMENTAL_ALLERGEN = "162554AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  FOOD_ALLERGEN = "162553AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  MILD_REACTION_SEVERITY = "1498AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  MODERATE_REACTION_SEVERITY = "1499AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  SEVERE_REACTION_SEVERITY = "1500AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+}
+
 type AllergyFormProps = DataCaptureComponentProps & { match: match };
 
-type Allergy = {
+type AllergyData = {
   allergenType: string;
   codedAllergenUuid: string;
   severityUuid: string;
   comment: string;
-  reactionsUuid: any[];
+  reactionUuids: string[];
 };

--- a/src/widgets/allergies/allergy-form.css
+++ b/src/widgets/allergies/allergy-form.css
@@ -17,7 +17,7 @@
 }
 
 .allergyEditHeader h3,
-h4 {
+.allergyEditHeader h4 {
   margin: 0rem 0rem 0.25rem 0rem;
   padding: 0rem;
 }

--- a/src/widgets/allergies/allergy-form.test.tsx
+++ b/src/widgets/allergies/allergy-form.test.tsx
@@ -89,7 +89,7 @@ describe("<AllergyForm />", () => {
     expect(screen.getByLabelText("Environmental")).toBeInTheDocument();
     expect(screen.getByLabelText("Food")).toBeInTheDocument();
     expect(
-      screen.getByLabelText("Patient has no allergies")
+      screen.getByLabelText("Patient has no known allergies")
     ).toBeInTheDocument();
 
     const environmentalAllergenCheckbox = screen.getByLabelText(

--- a/src/widgets/allergies/allergy-form.test.tsx
+++ b/src/widgets/allergies/allergy-form.test.tsx
@@ -156,7 +156,7 @@ describe("<AllergyForm />", () => {
         reactionUuids: [{ uuid: "121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" }],
         severityUuid: null
       },
-      "8673ee4f-e2ab-4077-ba55-4980f408773e",
+      patient.id,
       new AbortController()
     );
   });
@@ -243,18 +243,19 @@ describe("<AllergyForm />", () => {
 
     expect(mockDeletePatientAllergy).toHaveBeenCalledTimes(1);
     expect(mockDeletePatientAllergy).toHaveBeenCalledWith(
-      "8673ee4f-e2ab-4077-ba55-4980f408773e",
-      { allergyUuid: "4ef4abef-57b3-4df0-b5c1-41c763e34965" },
+      patient.id,
+      { allergyUuid: match.params["allergyUuid"] },
       new AbortController()
     );
 
     // Clicking Sign & Save publishes an allergy record
     fireEvent.click(submitBtn);
+
     expect(mockUpdatePatientAllergy).toHaveBeenCalledTimes(1);
     expect(mockUpdatePatientAllergy).toHaveBeenCalledWith(
       {
         allergenType: "DRUG",
-        codedAllergenUuid: undefined,
+        codedAllergenUuid: "921fbd85-fa49-46c3-9ee1-77e093fd10a5",
         severityUuid: "1499AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         comment:
           "The patient is showing a mild reaction to the above allergens",
@@ -265,8 +266,8 @@ describe("<AllergyForm />", () => {
           }
         ]
       },
-      "8673ee4f-e2ab-4077-ba55-4980f408773e",
-      { allergyUuid: "4ef4abef-57b3-4df0-b5c1-41c763e34965" },
+      patient.id,
+      { allergyUuid: match.params["allergyUuid"] },
       new AbortController()
     );
   });

--- a/src/widgets/allergies/allergy-intolerance.resource.tsx
+++ b/src/widgets/allergies/allergy-intolerance.resource.tsx
@@ -4,7 +4,7 @@ import {
   fhirBaseUrl
 } from "@openmrs/esm-api";
 import { map } from "rxjs/operators";
-import { AllergyData, AllergicReaction } from "../types";
+import { AllergyData, AllergicReaction, FHIRAllergy } from "../types";
 
 const ALLERGY_REACTION_CONCEPT = "162555AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
@@ -50,9 +50,9 @@ function mapAllergyProperties(allergy) {
   return formattedAllergy;
 }
 
-function formatAllergies(allergies) {
-  let formattedAllergies = [];
-  allergies?.forEach(allergy => {
+function formatAllergies(allergies: Array<FHIRAllergy>): Array<Allergy> {
+  let formattedAllergies: Array<Allergy> = [];
+  allergies?.forEach((allergy: FHIRAllergy) => {
     formattedAllergies.push(mapAllergyProperties(allergy));
   });
   return formattedAllergies;

--- a/src/widgets/allergies/allergy-intolerance.resource.tsx
+++ b/src/widgets/allergies/allergy-intolerance.resource.tsx
@@ -3,8 +3,8 @@ import {
   openmrsObservableFetch,
   fhirBaseUrl
 } from "@openmrs/esm-api";
-import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
+import { AllergyData, AllergicReaction } from "../types";
 
 const ALLERGY_REACTION_CONCEPT = "162555AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
@@ -20,7 +20,7 @@ export function performPatientAllergySearch(patientIdentifier: string) {
 }
 
 export function fetchAllergyByUuid(allergyUuid: string) {
-  return openmrsObservableFetch(
+  return openmrsObservableFetch<Allergy>(
     `${fhirBaseUrl}/AllergyIntolerance/${allergyUuid}`
   ).pipe(
     map(({ data }) => data),
@@ -65,7 +65,7 @@ export function getAllergyAllergenByConceptUuid(allergyUuid: string) {
 }
 
 export function getAllergicReactions() {
-  return openmrsObservableFetch(
+  return openmrsObservableFetch<Array<AllergicReaction>>(
     `/ws/rest/v1/concept/${ALLERGY_REACTION_CONCEPT}?v=full`
   ).pipe(map(({ data }) => data["setMembers"]));
 }
@@ -110,7 +110,7 @@ export function getPatientAllergyByPatientUuid(
   allergyUuid: any,
   abortController: AbortController
 ) {
-  return openmrsFetch(
+  return openmrsFetch<AllergyData>(
     `/ws/rest/v1/patient/${patientUuid}/allergy/${allergyUuid.allergyUuid}?v=full`,
     {
       signal: abortController.signal
@@ -171,8 +171,8 @@ export function deletePatientAllergy(
   );
 }
 
-type Allergy = {
-  id: String;
+export type Allergy = {
+  id: string;
   clinicalStatus: string;
   criticality: string;
   display: string;

--- a/src/widgets/allergies/allergy-intolerance.resource.tsx
+++ b/src/widgets/allergies/allergy-intolerance.resource.tsx
@@ -41,7 +41,7 @@ function mapAllergyProperties(allergy) {
     recordedDate: allergy?.recordedDate,
     recordedBy: allergy?.recorder?.display,
     recorderType: allergy?.recorder?.type,
-    note: allergy?.note[0]?.text,
+    note: allergy?.note?.[0]?.text,
     reactionToSubstance: allergy?.reaction[0]?.substance?.coding[1]?.display,
     reactionManifestations: manifestations,
     reactionSeverity: allergy?.reaction[0]?.severity,

--- a/src/widgets/allergies/allergy-intolerance.resource.tsx
+++ b/src/widgets/allergies/allergy-intolerance.resource.tsx
@@ -58,6 +58,19 @@ function formatAllergies(allergies) {
   return formattedAllergies;
 }
 
+export function getPatientAllergyByPatientUuid(
+  patientUuid: string,
+  allergyUuid: any,
+  abortController: AbortController
+) {
+  return openmrsFetch<AllergyData>(
+    `/ws/rest/v1/patient/${patientUuid}/allergy/${allergyUuid.allergyUuid}?v=full`,
+    {
+      signal: abortController.signal
+    }
+  );
+}
+
 export function getAllergyAllergenByConceptUuid(allergyUuid: string) {
   return openmrsObservableFetch(
     `/ws/rest/v1/concept/${allergyUuid}?v=full`
@@ -103,19 +116,6 @@ export function savePatientAllergy(
     },
     signal: abortController.signal
   });
-}
-
-export function getPatientAllergyByPatientUuid(
-  patientUuid: string,
-  allergyUuid: any,
-  abortController: AbortController
-) {
-  return openmrsFetch<AllergyData>(
-    `/ws/rest/v1/patient/${patientUuid}/allergy/${allergyUuid.allergyUuid}?v=full`,
-    {
-      signal: abortController.signal
-    }
-  );
 }
 
 export function updatePatientAllergy(

--- a/src/widgets/allergies/allergy-record.component.tsx
+++ b/src/widgets/allergies/allergy-record.component.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useRouteMatch } from "react-router-dom";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
-import { fetchAllergyByUuid } from "./allergy-intolerance.resource";
+import { Allergy, fetchAllergyByUuid } from "./allergy-intolerance.resource";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import styles from "./allergy-record.css";
 import dayjs from "dayjs";
@@ -11,10 +11,9 @@ import { openWorkspaceTab } from "../shared-utils";
 import RecordDetails from "../../ui-components/cards/record-details-card.component";
 
 export default function AllergyRecord(props: AllergyRecordProps) {
-  const [allergy, setAllergy] = useState(null);
+  const [allergy, setAllergy] = useState<Allergy>(null);
   const [isLoadingPatient, patient, patientUuid] = useCurrentPatient();
-
-  let match: any = useRouteMatch();
+  const match = useRouteMatch();
 
   useEffect(() => {
     if (!isLoadingPatient && patient && match.params["allergyUuid"]) {

--- a/src/widgets/allergies/allergy-record.component.tsx
+++ b/src/widgets/allergies/allergy-record.component.tsx
@@ -1,14 +1,14 @@
 import React, { useState, useEffect } from "react";
 import { useRouteMatch } from "react-router-dom";
-import { createErrorHandler } from "@openmrs/esm-error-handling";
-import { Allergy, fetchAllergyByUuid } from "./allergy-intolerance.resource";
-import { useCurrentPatient } from "@openmrs/esm-api";
-import styles from "./allergy-record.css";
 import dayjs from "dayjs";
-import SummaryCard from "../../ui-components/cards/summary-card.component";
-import AllergyForm from "./allergy-form.component";
+import { useCurrentPatient } from "@openmrs/esm-api";
+import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { openWorkspaceTab } from "../shared-utils";
+import SummaryCard from "../../ui-components/cards/summary-card.component";
 import RecordDetails from "../../ui-components/cards/record-details-card.component";
+import { Allergy, fetchAllergyByUuid } from "./allergy-intolerance.resource";
+import AllergyForm from "./allergy-form.component";
+import styles from "./allergy-record.css";
 
 export default function AllergyRecord(props: AllergyRecordProps) {
   const [allergy, setAllergy] = useState<Allergy>(null);

--- a/src/widgets/allergies/allergy-record.component.tsx
+++ b/src/widgets/allergies/allergy-record.component.tsx
@@ -49,7 +49,7 @@ export default function AllergyRecord(props: AllergyRecordProps) {
               }`}
             >
               <div className={`omrs-type-title-3 ${styles.allergyName}`}>
-                <span>{allergy?.display}</span>
+                <span>{allergy.display}</span>
               </div>
               <table className={styles.allergyTable}>
                 <thead className="omrs-type-body-regular">
@@ -66,12 +66,12 @@ export default function AllergyRecord(props: AllergyRecordProps) {
                         className={`${styles.centerItems} ${
                           styles.reactionSeverity
                         } ${
-                          allergy?.reactionSeverity === Severity.Severe
+                          allergy.reactionSeverity === Severity.Severe
                             ? `omrs-bold`
                             : ``
                         }`}
                       >
-                        {allergy?.reactionSeverity === Severity.Severe && (
+                        {allergy.reactionSeverity === Severity.Severe && (
                           <svg
                             className="omrs-icon"
                             fill="var(--omrs-color-danger)"
@@ -83,13 +83,13 @@ export default function AllergyRecord(props: AllergyRecordProps) {
                       </div>
                     </td>
                     <td>
-                      {allergy?.reactionManifestations
-                        ? allergy?.reactionManifestations?.join(", ")
+                      {allergy.reactionManifestations
+                        ? allergy.reactionManifestations?.join(", ")
                         : ""}
                     </td>
                     <td>
-                      {allergy?.recordedDate
-                        ? dayjs(allergy?.recordedDate).format("MMM-YYYY")
+                      {allergy.recordedDate
+                        ? dayjs(allergy.recordedDate).format("MMM-YYYY")
                         : "-"}
                     </td>
                   </tr>
@@ -104,7 +104,7 @@ export default function AllergyRecord(props: AllergyRecordProps) {
                   </thead>
                   <tbody>
                     <tr>
-                      <td>{allergy?.note}</td>
+                      <td>{allergy.note}</td>
                     </tr>
                   </tbody>
                 </table>
@@ -127,11 +127,11 @@ export default function AllergyRecord(props: AllergyRecordProps) {
                 <tbody>
                   <tr>
                     <td>
-                      {allergy?.lastUpdated
-                        ? dayjs(allergy?.lastUpdated).format("DD-MMM-YYYY")
+                      {allergy.lastUpdated
+                        ? dayjs(allergy.lastUpdated).format("DD-MMM-YYYY")
                         : "-"}
                     </td>
-                    <td>{allergy?.recordedBy}</td>
+                    <td>{allergy.recordedBy}</td>
                     <td>-</td>
                   </tr>
                 </tbody>

--- a/src/widgets/allergies/allergy-record.component.tsx
+++ b/src/widgets/allergies/allergy-record.component.tsx
@@ -1,165 +1,145 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { useRouteMatch } from "react-router-dom";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
-import { getPatientAllergyByPatientUuid } from "./allergy-intolerance.resource";
+import { fetchAllergyByUuid } from "./allergy-intolerance.resource";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import styles from "./allergy-record.css";
 import dayjs from "dayjs";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import AllergyForm from "./allergy-form.component";
 import { openWorkspaceTab } from "../shared-utils";
+import RecordDetails from "../../ui-components/cards/record-details-card.component";
 
 export default function AllergyRecord(props: AllergyRecordProps) {
-  const [allergy, setAllergy] = React.useState(null);
+  const [allergy, setAllergy] = useState(null);
   const [isLoadingPatient, patient, patientUuid] = useCurrentPatient();
 
-  let match = useRouteMatch();
+  let match: any = useRouteMatch();
 
-  React.useEffect(() => {
-    if (!isLoadingPatient && patient) {
-      const abortController = new AbortController();
+  useEffect(() => {
+    if (!isLoadingPatient && patient && match.params["allergyUuid"]) {
+      const sub = fetchAllergyByUuid(match.params["allergyUuid"]).subscribe(
+        allergy => setAllergy(allergy),
+        createErrorHandler()
+      );
 
-      getPatientAllergyByPatientUuid(
-        patientUuid,
-        { allergyUuid: match.params["allergyUuid"] },
-        abortController
-      )
-        .then(allergy => setAllergy(allergy.data))
-        .catch(createErrorHandler());
-
-      return () => abortController.abort();
+      return () => sub.unsubscribe();
     }
-  }, [isLoadingPatient, patient, patientUuid, match.params]);
-
-  function displayAllergy() {
-    return (
-      <SummaryCard
-        name="Allergy"
-        styles={{ width: "100%" }}
-        editComponent={AllergyForm}
-        showComponent={() =>
-          openWorkspaceTab(AllergyForm, "Edit Allergy", {
-            allergyUuid: allergy.uuid
-          })
-        }
-        link={`/patient/${patientUuid}/chart/allergies`}
-      >
-        <div
-          className={`omrs-type-body-regular ${styles.allergyCard} ${
-            allergy.severity.display === Severity.Severe
-              ? `${styles.highSeverity}`
-              : `${styles.lowSeverity}`
-          }`}
-        >
-          <div className={`omrs-type-title-3 ${styles.allergyName}`}>
-            <span data-testid="allergy-name">{allergy.display}</span>
-          </div>
-          <table className={styles.allergyTable}>
-            <thead className="omrs-type-body-regular">
-              <tr>
-                <th>Severity</th>
-                <th>Reaction</th>
-                <th>Onset Date</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td data-testid="severity">
-                  <div
-                    className={`${styles.centerItems} ${
-                      styles.allergySeverity
-                    } ${
-                      allergy.severity.display === Severity.Severe
-                        ? `omrs-bold`
-                        : ``
-                    }`}
-                  >
-                    {allergy.severity.display === Severity.Severe && (
-                      <svg
-                        className={`omrs-icon`}
-                        fontSize={"15px"}
-                        fill="var(--omrs-color-danger)"
-                      >
-                        <use xlinkHref="#omrs-icon-important-notification" />
-                      </svg>
-                    )}
-                    {allergy.severity.display}
-                  </div>
-                </td>
-                <td data-testid="reaction">
-                  {allergy.reactions
-                    .map(rxn => rxn.reaction.display)
-                    .join(", ")}
-                </td>
-                {/* Onset date is not yet available from the API response */}
-                <td data-testid="onset-date">-</td>
-              </tr>
-            </tbody>
-          </table>
-          {allergy.comment && (
-            <table className={styles.allergyTable}>
-              <thead className="omrs-type-body-regular">
-                <tr>
-                  <th>Comments</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr data-testid="comment">
-                  <td>{allergy.comment}</td>
-                </tr>
-              </tbody>
-            </table>
-          )}
-          <div className={styles.allergyFooter}></div>
-        </div>
-      </SummaryCard>
-    );
-  }
-
-  function displayDetails() {
-    return (
-      <SummaryCard
-        name="Details"
-        styles={{
-          width: "100%",
-          background: "var(--omrs-color-bg-medium-contrast)"
-        }}
-      >
-        <div className={styles.allergyCard}>
-          <table className={`${styles.allergyTable} ${styles.allergyDetails}`}>
-            <thead className="omrs-type-body-regular">
-              <tr>
-                <th>Last updated</th>
-                <th>Last updated by</th>
-                <th>Last updated location</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td data-testid="last-updated">
-                  {allergy.auditInfo.dateChanged
-                    ? dayjs(allergy.auditInfo.dateChanged).format("DD-MMM-YYYY")
-                    : "-"}
-                </td>
-                <td data-testid="updated-by">
-                  {allergy.auditInfo.creator.display}
-                </td>
-                <td data-testid="update-location">-</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </SummaryCard>
-    );
-  }
+  }, [isLoadingPatient, patient, match.params]);
 
   return (
     <>
-      {allergy && (
-        <div className={styles.allergySummary}>{displayAllergy()}</div>
-      )}
-      {allergy && (
-        <div className={styles.allergySummary}>{displayDetails()}</div>
+      {!!(allergy && Object.entries(allergy).length) && (
+        <div className={styles.allergyContainer}>
+          <SummaryCard
+            name="Allergy"
+            styles={{ width: "100%" }}
+            editComponent={AllergyForm}
+            showComponent={() =>
+              openWorkspaceTab(AllergyForm, "Edit Allergy", {
+                allergyUuid: allergy.id
+              })
+            }
+            link={`/patient/${patientUuid}/chart/allergies`}
+          >
+            <div
+              className={`omrs-type-body-regular ${styles.allergyCard} ${
+                allergy.reactionSeverity === "Severe"
+                  ? `${styles.highSeverity}`
+                  : `${styles.lowSeverity}`
+              }`}
+            >
+              <div className={`omrs-type-title-3 ${styles.allergyName}`}>
+                <span>{allergy?.display}</span>
+              </div>
+              <table className={styles.allergyTable}>
+                <thead className="omrs-type-body-regular">
+                  <tr>
+                    <th>Severity</th>
+                    <th>Reaction</th>
+                    <th>Onset Date</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      <div
+                        className={`${styles.centerItems} ${
+                          styles.reactionSeverity
+                        } ${
+                          allergy?.reactionSeverity === Severity.Severe
+                            ? `omrs-bold`
+                            : ``
+                        }`}
+                      >
+                        {allergy?.reactionSeverity === Severity.Severe && (
+                          <svg
+                            className="omrs-icon"
+                            fill="var(--omrs-color-danger)"
+                          >
+                            <use xlinkHref="#omrs-icon-important-notification" />
+                          </svg>
+                        )}
+                        {allergy.reactionSeverity}
+                      </div>
+                    </td>
+                    <td>
+                      {allergy?.reactionManifestations
+                        ? allergy?.reactionManifestations?.join(", ")
+                        : ""}
+                    </td>
+                    <td>
+                      {allergy?.recordedDate
+                        ? dayjs(allergy?.recordedDate).format("MMM-YYYY")
+                        : "-"}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              {allergy?.note && (
+                <table className={styles.allergyTable}>
+                  <thead className="omrs-type-body-regular">
+                    <tr>
+                      <th>Comments</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>{allergy?.note}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              )}
+              <div className={styles.allergyFooter}></div>
+            </div>
+          </SummaryCard>
+          <RecordDetails>
+            <div className={styles.allergyCard}>
+              <table
+                className={`${styles.allergyTable} ${styles.allergyDetails}`}
+              >
+                <thead className="omrs-type-body-regular">
+                  <tr>
+                    <th>Last updated</th>
+                    <th>Last updated by</th>
+                    <th>Last updated location</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      {allergy?.lastUpdated
+                        ? dayjs(allergy?.lastUpdated).format("DD-MMM-YYYY")
+                        : "-"}
+                    </td>
+                    <td>{allergy?.recordedBy}</td>
+                    <td>-</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </RecordDetails>
+        </div>
       )}
     </>
   );

--- a/src/widgets/allergies/allergy-record.component.tsx
+++ b/src/widgets/allergies/allergy-record.component.tsx
@@ -28,7 +28,7 @@ export default function AllergyRecord(props: AllergyRecordProps) {
 
   return (
     <>
-      {!!(allergy && Object.entries(allergy).length) && (
+      {allergy && Object.entries(allergy).length && (
         <div className={styles.allergyContainer}>
           <SummaryCard
             name="Allergy"
@@ -82,11 +82,7 @@ export default function AllergyRecord(props: AllergyRecordProps) {
                         {allergy.reactionSeverity}
                       </div>
                     </td>
-                    <td>
-                      {allergy.reactionManifestations
-                        ? allergy.reactionManifestations?.join(", ")
-                        : ""}
-                    </td>
+                    <td>{allergy.reactionManifestations?.join(", ") || ""}</td>
                     <td>
                       {allergy.recordedDate
                         ? dayjs(allergy.recordedDate).format("MMM-YYYY")

--- a/src/widgets/allergies/allergy-record.css
+++ b/src/widgets/allergies/allergy-record.css
@@ -8,7 +8,7 @@
 
 .allergyContainer {
   display: grid;
-  grid-gap: 25px;
+  grid-gap: 1.625rem;
 }
 
 .allergyCard {
@@ -66,4 +66,11 @@
 
 .lowSeverity {
   border-left: none;
+}
+
+.reactionSeverity {
+  text-transform: uppercase;
+  letter-spacing: 0.063rem;
+  line-height: 1rem;
+  font-weight: 500;
 }

--- a/src/widgets/profile/demographics-card.test.tsx
+++ b/src/widgets/profile/demographics-card.test.tsx
@@ -51,7 +51,7 @@ describe("<DemographicsCard>", () => {
         <DemographicsCard match={match} patient={patient} />
       </BrowserRouter>
     );
-    expect(getByTitle("age").textContent).toBe("17 yr 3 mo");
+    expect(getByTitle("age").textContent).toMatch(/17 yr [23] mo/);
   });
 
   it("renders the correct age for a 17 year old who had their birthday three months and one day ago", () => {

--- a/src/widgets/shared-utils.tsx
+++ b/src/widgets/shared-utils.tsx
@@ -30,6 +30,11 @@ export function openWorkspaceTab<
   }
 }
 
+export function capitalize(s): string {
+  if (typeof s !== "string") return "";
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
 export type DataCaptureComponentProps = {
   entryStarted: () => void;
   entrySubmitted: () => void;

--- a/src/widgets/types.ts
+++ b/src/widgets/types.ts
@@ -1,20 +1,12 @@
 export interface PatientProgram {
   uuid: string;
-  patient?: {
-    uuid?: string;
-    display?: string;
-    links: Links;
-  };
+  patient?: DisplayMetadata;
   program: {
     uuid: string;
     name: string;
     allWorkflows: Array<{
       uuid: string;
-      concept: {
-        uuid: string;
-        display: string;
-        links: Links;
-      };
+      concept: DisplayMetadata;
       retired: boolean;
       states: Array<{}>;
       links?: Links;
@@ -59,11 +51,7 @@ export interface SessionData {
   currentProvider: {
     uuid: string;
     display: string;
-    person: {
-      uuid: string;
-      display: string;
-      links: Links;
-    };
+    person: DisplayMetadata;
     identifier: string;
     attributes: Array<{}>;
     retired: boolean;
@@ -81,16 +69,8 @@ export interface SessionData {
     display: string;
     username: string;
   };
-  privileges: Array<{
-    uuid: string;
-    display: string;
-    links: Links;
-  }>;
-  roles: Array<{
-    uuid: string;
-    display: string;
-    links: Links;
-  }>;
+  privileges: Array<DisplayMetadata>;
+  roles: Array<DisplayMetadata>;
   retired: false;
   links: Links;
 }
@@ -205,7 +185,7 @@ type Links = Array<{
 }>;
 
 type DisplayMetadata = {
-  display: string;
-  links: Links;
-  uuid: string;
+  display?: string;
+  links?: Links;
+  uuid?: string;
 };

--- a/src/widgets/types.ts
+++ b/src/widgets/types.ts
@@ -95,11 +95,6 @@ export interface SessionData {
   links: Links;
 }
 
-type Links = Array<{
-  rel: string;
-  uri: string;
-}>;
-
 export type PatientNotes = {
   uuid: string;
   display: string;
@@ -116,4 +111,101 @@ export type PatientNotes = {
     dateChanged?: Date;
   };
   encounterProviders: [{ provider: { person: { display: string } } }];
+};
+
+export interface AllergyData {
+  allergen: {
+    allergenType: string;
+    codedAllergen: {
+      answers: [];
+      attrributes: [];
+      conceptClass: DisplayMetadata;
+      display: string;
+      links: Links;
+      mappings: DisplayMetadata[];
+      name: {
+        conceptNameType: string;
+        display: string;
+        locale: string;
+        name: string;
+        uuid: string;
+      };
+      names: DisplayMetadata[];
+      setMembers: [];
+      uuid: string;
+    };
+  };
+  auditInfo: {
+    changedBy: DisplayMetadata;
+    creator: DisplayMetadata;
+    dateCreated: string;
+    dateChanged: string;
+  };
+  comment: string;
+  display: string;
+  links: Links;
+  reactions: [
+    {
+      reaction: AllergicReaction;
+    }
+  ];
+  severity: {
+    name: {
+      conceptNameType: string;
+      display: string;
+      locale: string;
+      name: string;
+      uuid: string;
+    };
+    names: DisplayMetadata[];
+    uuid: string;
+  };
+}
+
+export type Allergen = {
+  answers: [];
+  attributes: [];
+  conceptClass: DisplayMetadata;
+  dataType: DisplayMetadata;
+  descriptions: [];
+  display: string;
+  links: Links;
+  mappings: Array<DisplayMetadata>;
+  name: {
+    display: string;
+    links: Links;
+    uuid: string;
+    conceptTypeName: string | null;
+    locale: string;
+    localePreferred: boolean;
+    name: string;
+    resourceVersion: string;
+  };
+  names: DisplayMetadata[];
+  setMembers: [];
+  uuid: string;
+};
+
+export type AllergicReaction = {
+  answers: [];
+  attributes: [];
+  conceptClass: DisplayMetadata;
+  datatype: DisplayMetadata;
+  descriptions: DisplayMetadata[];
+  name: {
+    display: string;
+  };
+  display: string;
+  uuid: string;
+};
+
+type Links = Array<{
+  rel: string;
+  uri: string;
+}>;
+
+type DisplayMetadata = {
+  display: string;
+  links: Links;
+  uuid: string;
 };

--- a/src/widgets/types.ts
+++ b/src/widgets/types.ts
@@ -93,6 +93,64 @@ export type PatientNotes = {
   encounterProviders: [{ provider: { person: { display: string } } }];
 };
 
+export interface FHIRAllergy {
+  category: string[];
+  clinicalStatus: {
+    coding: CodingData[];
+    text: string;
+  };
+  code: {
+    coding: CodingData[];
+  };
+  criticality: string;
+  id: string;
+  note: [
+    {
+      text: string;
+    }
+  ];
+  patient: {
+    display: string;
+    identifier: {
+      id: string;
+      system: string;
+      use: string;
+      value: string;
+    };
+    reference: string;
+    type: string;
+  };
+  reaction: FHIRAllergicReaction[];
+  recordedDate: string;
+  recorder: {
+    display: string;
+    reference: string;
+    type: string;
+  };
+  resourceType: string;
+  type: string;
+}
+
+interface FHIRAllergicReaction {
+  manifestation: CodingData[];
+  severity: string;
+  substance: {
+    coding: CodingData[];
+  };
+}
+
+interface CodingData {
+  code: string;
+  display: string;
+  extension?: ExtensionData[];
+  system?: string;
+}
+
+interface ExtensionData {
+  extension: [];
+  url: string;
+}
+
 export interface AllergyData {
   allergen: {
     allergenType: string;


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-171

This PR refactors the allergies widget to get it working with the FHIR2 allergies API (which introduced some breaking changes to the Allergy model). It also:

- Refactors `AllergyRecord` component to reuse the `RecordDetails` component.
- Improves the allergies test suite - statement coverage brought up to 96%.
- Refactors `AllergyForm` component so that: 
  - constants are now stored in one place.
  - there is a clearer separation of logic between the edit form and the create form.
  - there are better unit tests.
  - it uses better type annotations.

Screenshots:

<img width="332" alt="Screenshot 2020-06-08 at 22 56 15" src="https://user-images.githubusercontent.com/8509731/84075055-2660d180-a9dc-11ea-8d0c-ccb342b4c19b.png">

<img width="334" alt="Screenshot 2020-06-08 at 22 56 28" src="https://user-images.githubusercontent.com/8509731/84075071-2d87df80-a9dc-11ea-95ed-9d2355a94919.png">

<img width="1029" alt="Screenshot 2020-06-04 at 23 14 14" src="https://user-images.githubusercontent.com/8509731/83805943-67de3d80-a6b9-11ea-8f27-63c283c4fe19.png">

<img width="1030" alt="Screenshot 2020-06-04 at 23 13 23" src="https://user-images.githubusercontent.com/8509731/83805955-6c0a5b00-a6b9-11ea-9862-997a713905eb.png">