### PR TITLE
MF-161: fixed revised/expired  orders not appearing in past meds

### DIFF
--- a/src/widgets/medications/medications-detailed-summary.component.tsx
+++ b/src/widgets/medications/medications-detailed-summary.component.tsx
@@ -32,19 +32,23 @@ export default function MedicationsDetailedSummary(
     if (patientUuid) {
       const sub = fetchPatientMedications(patientUuid).subscribe(
         medications => {
-          const currentMeds = [];
-          const pastMeds = [];
-          medications.map((med: any) =>
-            med.action === "NEW" ? currentMeds.push(med) : pastMeds.push(med)
-          );
-
           setPatientMedications(medications);
-          setCurrentMedications(currentMeds);
-          setPastMedications(pastMeds);
+          setCurrentMedications(medications);
         },
         createErrorHandler()
       );
-      return () => sub.unsubscribe();
+      const sub2 = fetchPatientMedications(patientUuid, "any").subscribe(
+        medications => {
+          setPastMedications(
+            medications.sort(
+              (a: any, b: any) =>
+                new Date(b.dateActivated).getDate() -
+                new Date(a.dateActivated).getDate()
+            )
+          );
+        }
+      );
+      return () => sub.unsubscribe && sub2.unsubscribe();
     }
   }, [patientUuid]);
 

--- a/src/widgets/medications/medications-detailed-summary.test.tsx
+++ b/src/widgets/medications/medications-detailed-summary.test.tsx
@@ -55,42 +55,36 @@ describe("<MedicationsDetailedSummary/>", () => {
       of(mockFetchPatientMedicationsResponse)
     );
 
-    wrapper = render(
+    const { getByText, getAllByText, container, debug } = render(
       <BrowserRouter>
         <MedicationsDetailedSummary />
       </BrowserRouter>
     );
 
     await wait(() => {
-      expect(wrapper).toBeDefined();
+      expect(container).toBeDefined();
       // Current medications
-      expect(
-        wrapper.getByText("Medications - current").textContent
-      ).toBeTruthy();
-      expect(wrapper.getAllByText("Add").length).toEqual(2);
-      expect(wrapper.getByText("NAME").textContent).toBeTruthy();
-      expect(wrapper.getByText("STATUS").textContent).toBeTruthy();
-      expect(wrapper.getByText("START DATE").textContent).toBeTruthy();
-      expect(wrapper.getByText("ACTIONS").textContent).toBeTruthy();
-      expect(wrapper.getByText("sulfadoxine").textContent).toBeTruthy();
-      expect(wrapper.getByText(/oral/).textContent).toBeTruthy();
-      expect(wrapper.getByText(/capsule/).textContent).toBeTruthy();
-      expect(wrapper.getByText("DOSE").textContent).toBeTruthy();
-      expect(wrapper.getByText("500 mg").textContent).toBeTruthy();
-      expect(wrapper.getByText(/Twice daily/).textContent).toBeTruthy();
-      expect(wrapper.getByText(/3 Days/).textContent).toBeTruthy();
-      expect(wrapper.getByText("REFILLS").textContent).toBeTruthy();
-      expect(wrapper.getByText("NEW").textContent).toBeTruthy();
-      expect(wrapper.getByText("12-Feb-2020").textContent).toBeTruthy();
-      expect(wrapper.getByText("Revise").textContent).toBeTruthy();
-      expect(wrapper.getByText("Discontinue").textContent).toBeTruthy();
-      // Past medications
-      expect(wrapper.getByText("Medications - past").textContent).toBeTruthy();
-      expect(
-        wrapper.getByText("No past medications are documented.").textContent
-      ).toBeTruthy();
+      expect(getByText("Medications - current").textContent).toBeTruthy();
+      expect(getAllByText("Add").length).toEqual(2);
+      expect(getByText("Medications - past").textContent).toBeTruthy();
+      expect(wrapper.getAllByText("NAME")[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText("STATUS")[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText("START DATE")[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText("ACTIONS")[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText("sulfadoxine")[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText(/oral/)[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText(/capsule/)[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText("DOSE")[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText("500 mg")[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText(/Twice daily/)[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText(/3 Days/)[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText("REFILLS")[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText("NEW")[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText("12-Feb-2020")[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText("Revise")[0].textContent).toBeTruthy();
+      expect(wrapper.getAllByText("Discontinue")[0].textContent).toBeTruthy();
     });
-  });
+  }, 6000);
 
   it("should not display the patient's medications when they are absent", async () => {
     mockFetchPatientMedications.mockReturnValue(of([]));

--- a/src/widgets/medications/medications-overview.component.tsx
+++ b/src/widgets/medications/medications-overview.component.tsx
@@ -33,12 +33,7 @@ export default function MedicationsOverview(props: MedicationsOverviewProps) {
     if (patientUuid) {
       const subscription = fetchPatientMedications(patientUuid).subscribe(
         medications => {
-          const inactiveStates = ["REVISE", "DISCONTINUE"];
-          setPatientMedications(
-            medications.filter(
-              (med: any) => !inactiveStates.includes(med.action)
-            )
-          );
+          setPatientMedications(medications);
         },
         createErrorHandler()
       );

--- a/src/widgets/medications/medications.resource.tsx
+++ b/src/widgets/medications/medications.resource.tsx
@@ -6,6 +6,7 @@ import {
 import { Observable } from "rxjs";
 import { map, take, filter } from "rxjs/operators";
 import { OrderMedication } from "./medication-orders-utils";
+import dayjs from "dayjs";
 
 const CARE_SETTING: string = "6f0c9a92-6f24-11e3-af88-005056821db0";
 const DURATION_UNITS_CONCEPT: string = "1732AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
@@ -29,10 +30,15 @@ export function performPatientMedicationsSearch(
 }
 
 export function fetchPatientMedications(
-  patientID: string
+  patientID: string,
+  status: string = "ACTIVE"
 ): Observable<PatientMedications[]> {
   return openmrsObservableFetch(
-    `/ws/rest/v1/order?patient=${patientID}&careSetting=${CARE_SETTING}&status=ACTIVE&v=custom:(uuid,orderNumber,accessionNumber,patient:ref,action,careSetting:ref,previousOrder:ref,dateActivated,scheduledDate,dateStopped,autoExpireDate,orderType:ref,encounter:ref,orderer:ref,orderReason,orderType,urgency,instructions,commentToFulfiller,drug:(name,strength,concept),dose,doseUnits:ref,frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,numRefills,dosingInstructions,duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)`
+    `/ws/rest/v1/order?patient=${patientID}&careSetting=${CARE_SETTING}&status=${status}&asOfDate=${dayjs(
+      new Date()
+    ).format(
+      "YYYY-MM-DD"
+    )}&v=custom:(uuid,orderNumber,accessionNumber,patient:ref,action,careSetting:ref,previousOrder:ref,dateActivated,scheduledDate,dateStopped,autoExpireDate,orderType:ref,encounter:ref,orderer:ref,orderReason,orderType,urgency,instructions,commentToFulfiller,drug:(name,strength,concept),dose,doseUnits:ref,frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,numRefills,dosingInstructions,duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)`
   ).pipe(
     map(({ data }) => {
       const meds = [];


### PR DESCRIPTION
This PR addresses showing expired and revised medication, but doesn't show discontinued orders because of the API has a bug not displaying discontinued orders
![Screenshot from 2020-05-12 15-24-35](https://user-images.githubusercontent.com/28008754/81691329-4f398980-9465-11ea-8778-aa01652c4044.png)
