### PR TITLE
Fix NotesOverview chartBasePath route

### DIFF
--- a/src/widgets/notes/notes-overview.component.tsx
+++ b/src/widgets/notes/notes-overview.component.tsx
@@ -25,7 +25,7 @@ export default function NotesOverview(props: NotesOverviewProps) {
   ] = useCurrentPatient();
 
   const { t } = useTranslation();
-  const [chartBasePath] = useChartBasePath();
+  const chartBasePath = useChartBasePath();
   const notesPath = chartBasePath + "/" + props.basePath;
 
   React.useEffect(() => {


### PR DESCRIPTION
Clicking on `See All` is not leading to the user being routed to the NotesDetailedSummary. The route produced from the link does not have a chartBasePath segment. 

Trivial; Probably a typo overlooked when effecting #65.