### PR TITLE
MF-213: Enable re-enrolling into completed programs

### DIFF
--- a/src/widgets/programs/programs-form.component.tsx
+++ b/src/widgets/programs/programs-form.component.tsx
@@ -64,7 +64,12 @@ export default function ProgramsForm(props: ProgramsFormProps) {
         createErrorHandler()
       );
       const sub3 = fetchEnrolledPrograms(patientUuid).subscribe(
-        enrolledPrograms => setEnrolledPrograms(enrolledPrograms),
+        enrolledPrograms =>
+          setEnrolledPrograms(
+            enrolledPrograms.filter(
+              enrolledProgram => !enrolledProgram.dateCompleted
+            )
+          ),
         createErrorHandler()
       );
 


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-213

It should be possible to re-enrol patients into programs they've already completed.

This commit fixes adds a check when determining a patient's enrolled programs so that only active enrollments are considered. Consequently, programs that a patient has unenrolled from will now be considered eligible for re-enrolment and will then appear in the Choose Program input when adding a new program.