### PR TITLE
Export AttachmentsOverview component

### DIFF
--- a/src/openmrs-esm-patient-chart-widgets.tsx
+++ b/src/openmrs-esm-patient-chart-widgets.tsx
@@ -57,3 +57,5 @@ export { default as VitalsForm } from "./widgets/vitals/vitals-form.component";
 
 export { default as VisitButton } from "./widgets/visit/visit-button-component";
 export { default as VisitDialog } from "./widgets/visit/visit-dialog-component";
+
+export { default as AttachmentsOverview } from "./widgets/attachments/attachments-overview.component";


### PR DESCRIPTION
This was initially added in https://github.com/openmrs/openmrs-esm-patient-chart-widgets/pull/39/files#diff-fd137497c23b601a671e749b524df383R58 but somehow it's not present in master even though that PR is already merged to master. This causes the UI to fail as it cannot find the `AttachmentsOverview` component.