### PR TITLE
MF-219: Add chart summary translations

### DIFF
--- a/src/ui-components/cards/summary-card-footer.component.tsx
+++ b/src/ui-components/cards/summary-card-footer.component.tsx
@@ -1,15 +1,19 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import styles from "./summary-card-footer.css";
+import { Trans } from "react-i18next";
 
 export default function SummaryCardFooter(props: SummaryCardFooterProps) {
   if (!props.linkTo) {
     return (
       <div className={styles.footer}>
-        <p className="omrs-bold">See all</p>
+        <p className="omrs-bold">
+          <Trans i18nKey="See all">See all</Trans>
+        </p>
       </div>
     );
   }
+
   return (
     <div className={`${styles.footer}`}>
       <svg className="omrs-icon" fill="var(--omrs-color-ink-medium-contrast)">
@@ -20,7 +24,9 @@ export default function SummaryCardFooter(props: SummaryCardFooterProps) {
         className={`omrs-unstyled`}
         style={{ border: "none" }}
       >
-        <p className="omrs-bold">See all</p>
+        <p className="omrs-bold">
+          <Trans i18nKey="See all">See all</Trans>
+        </p>
       </Link>
     </div>
   );

--- a/src/ui-components/cards/summary-card.component.tsx
+++ b/src/ui-components/cards/summary-card.component.tsx
@@ -25,7 +25,7 @@ export default function SummaryCard(props: SummaryCardProps) {
                 props.showComponent(props.addComponent, props.name)
               }
             >
-              Add
+              {t("Add", "Add")}
             </button>
           </div>
         )}
@@ -37,7 +37,7 @@ export default function SummaryCard(props: SummaryCardProps) {
                 props.showComponent(props.editComponent, props.name)
               }
             >
-              Edit
+              {t("Edit", "Edit")}
             </button>
           </div>
         )}
@@ -45,7 +45,7 @@ export default function SummaryCard(props: SummaryCardProps) {
           <div className={styles.headerEdit}>
             <button className={`omrs-unstyled ${styles.editBtn}`}>
               <Link className="omrs-unstyled" to={props.editBtnUrl}>
-                Edit
+                {t("Edit", "Edit")}
               </Link>
             </button>
           </div>

--- a/src/ui-components/empty-state/empty-state.component.tsx
+++ b/src/ui-components/empty-state/empty-state.component.tsx
@@ -3,6 +3,7 @@ import SummaryCard from "../cards/summary-card.component";
 import { DataCaptureComponentProps } from "../../widgets/shared-utils";
 import styles from "./empty-state.css";
 import { match } from "react-router-dom";
+import { Trans } from "react-i18next";
 
 export default function EmptyState(props: EmptyStateProps) {
   return (
@@ -15,7 +16,15 @@ export default function EmptyState(props: EmptyStateProps) {
         style={props.styles}
         className={`omrs-medium ${styles.emptyStateText}`}
       >
-        <p className="omrs-type-body-regular">{props.displayText}</p>
+        <p className="omrs-type-body-regular">
+          <Trans
+            i18nKey="emptyStateText"
+            values={{ displayText: props.displayText }}
+          >
+            This patient has no {props.displayText} recorded in the system
+          </Trans>
+          .
+        </p>
       </div>
     </SummaryCard>
   );

--- a/src/ui-components/sidebar/sidebar.component.tsx
+++ b/src/ui-components/sidebar/sidebar.component.tsx
@@ -4,23 +4,27 @@ import AllergyForm from "../../widgets/allergies/allergy-form.component";
 import Parcel from "single-spa-react/parcel";
 import VitalsForm from "../../widgets/vitals/vitals-form.component";
 import { openWorkspaceTab } from "../../widgets/shared-utils";
+import { useTranslation } from "react-i18next";
 
 export default function Sidebar(props: any) {
+  const { t } = useTranslation();
   const formentryParcel = () => (
     <Parcel config={System.import("@ampath/esm-angular-form-entry")} />
   );
   const sidebarItems = [
     {
       name: "A",
-      onclick: () => openWorkspaceTab(AllergyForm, "Allergy Form")
+      onclick: () =>
+        openWorkspaceTab(AllergyForm, `${t("Allergy Form", "Allergy Form")}`)
     },
     {
       name: "V",
-      onclick: () => openWorkspaceTab(VitalsForm, "Vitals")
+      onclick: () =>
+        openWorkspaceTab(VitalsForm, `${t("Vitals Form", "Vitals Form")}`)
     },
     {
       name: "F",
-      onclick: () => openWorkspaceTab(formentryParcel, "Forms")
+      onclick: () => openWorkspaceTab(formentryParcel, `${t("Forms", "Forms")}`)
     }
   ];
   return (

--- a/src/widgets/allergies/allergies-overview.component.tsx
+++ b/src/widgets/allergies/allergies-overview.component.tsx
@@ -40,14 +40,18 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
     <>
       {patientAllergies && patientAllergies.total > 0 ? (
         <SummaryCard
-          name="Allergies"
+          name={t("Allergies", "Allergies")}
           styles={{ margin: "1.25rem, 1.5rem" }}
           link={`/patient/${patientUuid}/chart/allergies`}
           addComponent={AllergyForm}
           showComponent={() => {
-            openWorkspaceTab(AllergyForm, "Allergy Form", {
-              allergyUuid: null
-            });
+            openWorkspaceTab(
+              AllergyForm,
+              `${t("Allergy Form", "Allergy Form")}`,
+              {
+                allergyUuid: null
+              }
+            );
           }}
         >
           {patientAllergies.entry.map(allergy => {
@@ -76,8 +80,13 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
         </SummaryCard>
       ) : (
         <EmptyState
-          showComponent={() => openWorkspaceTab(AllergyForm, "Allergy Form")}
           addComponent={AllergyForm}
+          showComponent={() =>
+            openWorkspaceTab(
+              AllergyForm,
+              `${t("Allergy Form", "Allergy Form")}`
+            )
+          }
           name="Allergies"
           displayText={t("allergy intolerances", "allergy intolerances")}
         />

--- a/src/widgets/allergies/allergies-overview.component.tsx
+++ b/src/widgets/allergies/allergies-overview.component.tsx
@@ -10,6 +10,7 @@ import { useCurrentPatient } from "@openmrs/esm-api";
 import AllergyForm from "./allergy-form.component";
 import { openWorkspaceTab } from "../shared-utils";
 import useChartBasePath from "../../utils/use-chart-base";
+import { useTranslation } from "react-i18next";
 
 export default function AllergiesOverview(props: AllergiesOverviewProps) {
   const [patientAllergies, setPatientAllergies] = React.useState(null);
@@ -21,6 +22,7 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
   ] = useCurrentPatient();
   const chartBasePath = useChartBasePath();
   const allergiesPath = chartBasePath + "/" + props.basePath;
+  const { t } = useTranslation();
 
   React.useEffect(() => {
     if (patient) {
@@ -77,7 +79,7 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
           showComponent={() => openWorkspaceTab(AllergyForm, "Allergy Form")}
           addComponent={AllergyForm}
           name="Allergies"
-          displayText="This patient has no allergy intolerances recorded in the system."
+          displayText={t("allergy intolerances", "allergy intolerances")}
         />
       )}
     </>

--- a/src/widgets/appointments/appointments-overview.component.tsx
+++ b/src/widgets/appointments/appointments-overview.component.tsx
@@ -41,10 +41,13 @@ export default function AppointmentsOverview(props: AppointmentOverviewProps) {
     <>
       {patientAppointments && patientAppointments.length > 0 ? (
         <SummaryCard
-          name="Appointments"
+          name={t("Appointments", "Appointments")}
           link={appointmentsPath}
           showComponent={() =>
-            openWorkspaceTab(AppointmentsForm, "Appointments Form")
+            openWorkspaceTab(
+              AppointmentsForm,
+              `${t("Appointments Form", "Appointments Form")}`
+            )
           }
           addComponent={AppointmentsForm}
         >
@@ -53,9 +56,9 @@ export default function AppointmentsOverview(props: AppointmentOverviewProps) {
           >
             <thead>
               <tr>
-                <td>Date</td>
-                <td>Service Type</td>
-                <td colSpan={2}>Status</td>
+                <td>{t("Date", "Date")}</td>
+                <td>{t("Service Type", "Service Type")}</td>
+                <td colSpan={2}>{t("Status", "Status")}</td>
               </tr>
             </thead>
             <tbody>
@@ -85,9 +88,13 @@ export default function AppointmentsOverview(props: AppointmentOverviewProps) {
         </SummaryCard>
       ) : (
         <EmptyState
-          name="Appointments"
+          name={t("Appointments", "Appointments")}
+          addComponent={AppointmentsForm}
           showComponent={() =>
-            openWorkspaceTab(AppointmentsForm, "Appointments Form")
+            openWorkspaceTab(
+              AppointmentsForm,
+              `${t("Appointments Form", "Appointments Form")}`
+            )
           }
           displayText={t("appointments", "appointments")}
         />

--- a/src/widgets/appointments/appointments-overview.component.tsx
+++ b/src/widgets/appointments/appointments-overview.component.tsx
@@ -10,6 +10,7 @@ import AppointmentsForm from "./appointments-form.component";
 import { Link } from "react-router-dom";
 import { openWorkspaceTab } from "../shared-utils";
 import useChartBasePath from "../../utils/use-chart-base";
+import { useTranslation } from "react-i18next";
 
 export default function AppointmentsOverview(props: AppointmentOverviewProps) {
   const [patientAppointments, setPatientAppointments] = React.useState([]);
@@ -22,6 +23,7 @@ export default function AppointmentsOverview(props: AppointmentOverviewProps) {
   const startDate = dayjs().format();
   const chartBasePath = useChartBasePath();
   const appointmentsPath = chartBasePath + "/" + props.basePath;
+  const { t } = useTranslation();
 
   React.useEffect(() => {
     if (!isLoadingPatient && patientUuid) {
@@ -83,12 +85,11 @@ export default function AppointmentsOverview(props: AppointmentOverviewProps) {
         </SummaryCard>
       ) : (
         <EmptyState
+          name="Appointments"
           showComponent={() =>
             openWorkspaceTab(AppointmentsForm, "Appointments Form")
           }
-          addComponent={AppointmentsForm}
-          name="Appointments"
-          displayText="This patient has no appointments recorded in the system."
+          displayText={t("appointments", "appointments")}
         />
       )}
     </>

--- a/src/widgets/conditions/conditions-overview.component.tsx
+++ b/src/widgets/conditions/conditions-overview.component.tsx
@@ -41,21 +41,26 @@ export default function ConditionsOverview(props: ConditionsOverviewProps) {
 
   return (
     <SummaryCard
-      name={t("conditions", "Conditions")}
+      name={t("Conditions", "Conditions")}
       styles={{ margin: "1.25rem, 1.5rem" }}
       link={conditionsPath}
       addComponent={ConditionsForm}
-      showComponent={() => openWorkspaceTab(ConditionsForm, "Conditions Form")}
+      showComponent={() =>
+        openWorkspaceTab(
+          ConditionsForm,
+          `${t("Conditions Form", "Conditions Form")}`
+        )
+      }
     >
       <SummaryCardRow>
         <SummaryCardRowContent>
           <HorizontalLabelValue
-            label="Active Conditions"
+            label={t("Active Conditions", "Active Conditions")}
             labelStyles={{
               color: "var(--omrs-color-ink-medium-contrast)",
               fontFamily: "Work Sans"
             }}
-            value="Since"
+            value={t("Since", "Since")}
             valueStyles={{
               color: "var(--omrs-color-ink-medium-contrast)",
               fontFamily: "Work Sans"

--- a/src/widgets/heightandweight/heightandweight-overview.component.tsx
+++ b/src/widgets/heightandweight/heightandweight-overview.component.tsx
@@ -11,6 +11,7 @@ import VitalsForm from "../vitals/vitals-form.component";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import { openWorkspaceTab } from "../shared-utils";
 import useChartBasePath from "../../utils/use-chart-base";
+import { useTranslation } from "react-i18next";
 
 export default function HeightAndWeightOverview(
   props: HeightAndWeightOverviewProps
@@ -25,6 +26,7 @@ export default function HeightAndWeightOverview(
   ] = useCurrentPatient();
   const chartBasePath = useChartBasePath();
   const heightweightPath = chartBasePath + "/" + props.basePath;
+  const { t } = useTranslation();
 
   React.useEffect(() => {
     if (patientUuid) {
@@ -114,7 +116,7 @@ export default function HeightAndWeightOverview(
           showComponent={() => openWorkspaceTab(VitalsForm, "Vitals Form")}
           addComponent={VitalsForm}
           name="Height & Weight"
-          displayText="This patient has no dimensions recorded in the system."
+          displayText={t("dimensions", "dimensions")}
         />
       )}
     </>

--- a/src/widgets/heightandweight/heightandweight-overview.component.tsx
+++ b/src/widgets/heightandweight/heightandweight-overview.component.tsx
@@ -42,9 +42,11 @@ export default function HeightAndWeightOverview(
     <>
       {dimensions.length > 0 ? (
         <SummaryCard
-          name="Height & Weight"
+          name={t("Height & Weight", "Height & Weight")}
           link={`${heightweightPath}`}
-          showComponent={() => openWorkspaceTab(VitalsForm, "Vitals Form")}
+          showComponent={() =>
+            openWorkspaceTab(VitalsForm, `${t("Vitals Form", "Vitals Form")}`)
+          }
           addComponent={VitalsForm}
         >
           <SummaryCardRow>
@@ -56,9 +58,13 @@ export default function HeightAndWeightOverview(
                       className={`${styles.tableHeader} ${styles.tableDates}`}
                       style={{ textAlign: "start" }}
                     ></th>
-                    <th className={styles.tableHeader}>Weight</th>
-                    <th className={styles.tableHeader}>Height</th>
-                    <th className={styles.tableHeader}>BMI</th>
+                    <th className={styles.tableHeader}>
+                      {t("Weight", "Weight")}
+                    </th>
+                    <th className={styles.tableHeader}>
+                      {t("Height", "Height")}
+                    </th>
+                    <th className={styles.tableHeader}>{t("BMI", "BMI")}</th>
                     <th></th>
                   </tr>
                 </thead>
@@ -113,7 +119,9 @@ export default function HeightAndWeightOverview(
         </SummaryCard>
       ) : (
         <EmptyState
-          showComponent={() => openWorkspaceTab(VitalsForm, "Vitals Form")}
+          showComponent={() =>
+            openWorkspaceTab(VitalsForm, `${t("Vitals Form", "Vitals Form")}`)
+          }
           addComponent={VitalsForm}
           name="Height & Weight"
           displayText={t("dimensions", "dimensions")}

--- a/src/widgets/medications/medications-overview.component.tsx
+++ b/src/widgets/medications/medications-overview.component.tsx
@@ -48,14 +48,18 @@ export default function MedicationsOverview(props: MedicationsOverviewProps) {
           name={t("Active Medications", "Active Medications")}
           styles={{ width: "100%" }}
           link={`${props.basePath}`}
+          addComponent={MedicationOrderBasket}
           showComponent={() =>
-            openWorkspaceTab(MedicationOrderBasket, "Medication Order")
+            openWorkspaceTab(
+              MedicationOrderBasket,
+              `${t("Medication Order", "Medication Order")}`
+            )
           }
         >
           <SummaryCardRow>
             <SummaryCardRowContent>
               <HorizontalLabelValue
-                label="Active Medications"
+                label={t("Active Medications", "Active Medications")}
                 labelStyles={{
                   color: "var(--omrs-color-ink-medium-contrast)",
                   fontFamily: "Work Sans"
@@ -86,7 +90,7 @@ export default function MedicationsOverview(props: MedicationsOverviewProps) {
                       style={{ color: "var(--omrs-color-ink-medium-contrast)" }}
                     >
                       {" "}
-                      DOSE
+                      {t("DOSE", "DOSE")}
                     </span>{" "}
                     <span
                       style={{
@@ -119,17 +123,16 @@ export default function MedicationsOverview(props: MedicationsOverviewProps) {
                     <MedicationButton
                       component={MedicationOrderBasket}
                       name={"Medication Order Basket"}
-                      label={"Revise"}
+                      label={t("Revise", "Revise")}
                       orderUuid={medication?.uuid}
                       drugName={medication?.drug?.name}
-                      action={"REVISE"}
                       inProgress={true}
                       btnClass="omrs-btn omrs-text-action"
                     />
                     <MedicationButton
                       component={MedicationOrderBasket}
                       name={"Medication Order Basket"}
-                      label={"Discontinue"}
+                      label={t("Discontinue", "Interrumpir")}
                       orderUuid={medication?.uuid}
                       drugName={null}
                       action={"DISCONTINUE"}
@@ -152,10 +155,13 @@ export default function MedicationsOverview(props: MedicationsOverviewProps) {
         </SummaryCard>
       ) : (
         <EmptyState
-          name="Active Medications"
+          name={t("Active Medications", "Active Medications")}
           addComponent={MedicationOrderBasket}
           showComponent={() =>
-            openWorkspaceTab(MedicationOrderBasket, "Medication Order")
+            openWorkspaceTab(
+              MedicationOrderBasket,
+              `${t("Medication Order", "Medication Order")}`
+            )
           }
           displayText={t("active medications", "active medications")}
         />

--- a/src/widgets/medications/medications-overview.component.tsx
+++ b/src/widgets/medications/medications-overview.component.tsx
@@ -152,12 +152,12 @@ export default function MedicationsOverview(props: MedicationsOverviewProps) {
         </SummaryCard>
       ) : (
         <EmptyState
+          name="Active Medications"
+          addComponent={MedicationOrderBasket}
           showComponent={() =>
             openWorkspaceTab(MedicationOrderBasket, "Medication Order")
           }
-          addComponent={MedicationOrderBasket}
-          name="Active Medications"
-          displayText="This patient has no active medications recorded in the system."
+          displayText={t("active medications", "active medications")}
         />
       )}
     </>

--- a/src/widgets/notes/notes-overview.component.tsx
+++ b/src/widgets/notes/notes-overview.component.tsx
@@ -96,9 +96,12 @@ export default function NotesOverview(props: NotesOverviewProps) {
           <table className={`omrs-type-body-regular ${styles.notesTable}`}>
             <thead>
               <tr className={styles.notesTableRow}>
-                <th>Date</th>
-                <th style={{ textAlign: "left" }}>Encounter type, Location</th>
-                <th style={{ textAlign: "left" }}>Author</th>
+                <th>{t("Date", "Date")}</th>
+                <th style={{ textAlign: "left" }}>
+                  {t("Encounter Type", "Encounter Type")},{" "}
+                  {t("Location", "Location")}
+                </th>
+                <th style={{ textAlign: "left" }}>{t("Author", "Author")}</th>
                 <th></th>
               </tr>
             </thead>

--- a/src/widgets/notes/notes-overview.component.tsx
+++ b/src/widgets/notes/notes-overview.component.tsx
@@ -134,10 +134,7 @@ export default function NotesOverview(props: NotesOverviewProps) {
           <SummaryCardFooter linkTo={notesPath} />
         </SummaryCard>
       ) : (
-        <EmptyState
-          name="Notes"
-          displayText="This patient has no notes recorded in the system."
-        />
+        <EmptyState name="Notes" displayText={t("notes", "notes")} />
       )}
     </>
   );

--- a/src/widgets/programs/programs-overview.component.tsx
+++ b/src/widgets/programs/programs-overview.component.tsx
@@ -87,7 +87,12 @@ export default function ProgramsOverview(props: ProgramsOverviewProps) {
         </SummaryCard>
       ) : (
         <EmptyState
-          showComponent={() => openWorkspaceTab(ProgramsForm, "Programs Form")}
+          showComponent={() =>
+            openWorkspaceTab(
+              ProgramsForm,
+              `${t("Programs Form", "Programs Form")}`
+            )
+          }
           addComponent={ProgramsForm}
           name="Care Programs"
           displayText={t("program enrollments", "program enrollments")}

--- a/src/widgets/programs/programs-overview.component.tsx
+++ b/src/widgets/programs/programs-overview.component.tsx
@@ -90,7 +90,7 @@ export default function ProgramsOverview(props: ProgramsOverviewProps) {
           showComponent={() => openWorkspaceTab(ProgramsForm, "Programs Form")}
           addComponent={ProgramsForm}
           name="Care Programs"
-          displayText="This patient has no program enrollments recorded in the system."
+          displayText={t("program enrollments", "program enrollments")}
         />
       )}
     </>

--- a/src/widgets/vitals/vitals-overview.component.tsx
+++ b/src/widgets/vitals/vitals-overview.component.tsx
@@ -124,10 +124,10 @@ export default function VitalsOverview(props: VitalsOverviewProps) {
         </SummaryCard>
       ) : (
         <EmptyState
+          name="Vitals"
           showComponent={() => openWorkspaceTab(VitalsForm, "Vitals Form")}
           addComponent={VitalsForm}
-          name="Vitals"
-          displayText="This patient has no vitals recorded in the system."
+          displayText={t("vitals", "vitals")}
         />
       )}
     </>

--- a/src/widgets/vitals/vitals-overview.component.tsx
+++ b/src/widgets/vitals/vitals-overview.component.tsx
@@ -57,19 +57,21 @@ export default function VitalsOverview(props: VitalsOverviewProps) {
     <>
       {currentVitals && currentVitals.length > 0 ? (
         <SummaryCard
-          name={t("vitals", "Vitals")}
+          name={t("Vitals", "Vitals")}
           link={props.basePath}
           addComponent={VitalsForm}
-          showComponent={() => openWorkspaceTab(VitalsForm, "Vitals Form")}
+          showComponent={() =>
+            openWorkspaceTab(VitalsForm, `${t("Vitals Form", "Vitals Form")}`)
+          }
         >
           <table className={`omrs-type-body-regular ${styles.vitalsTable}`}>
             <thead>
               <tr className="omrs-medium">
                 <td></td>
                 <td>BP</td>
-                <td>Rate</td>
-                <td>Oxygen</td>
-                <td colSpan={2}>Temp</td>
+                <td>{t("Rate", "Rate")}</td>
+                <td>{t("Oxygen", "Oxygen")}</td>
+                <td colSpan={2}>{t("Temp", "Temp")}</td>
               </tr>
             </thead>
             <tbody>
@@ -117,7 +119,7 @@ export default function VitalsOverview(props: VitalsOverviewProps) {
                 <use xlinkHref="#omrs-icon-chevron-down" />
               </svg>
               <button className="omrs-unstyled" onClick={loadMoreVitals}>
-                <p className="omrs-bold">More</p>
+                <p className="omrs-bold">{t("More", "More")}</p>
               </button>
             </div>
           )}


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-219

This is the beginning of efforts aimed at having full translation support across the patient chart summary.

EmptyState component:

<img width="522" alt="Screenshot 2020-05-18 at 14 01 41" src="https://user-images.githubusercontent.com/8509731/82206075-3b33d300-9910-11ea-99db-6770abbc232f.png">


Widget overview components:

<img width="1677" alt="Screenshot 2020-05-18 at 14 39 26" src="https://user-images.githubusercontent.com/8509731/82209132-6f5dc280-9915-11ea-9030-a2a15c7fcc17.png">

