### PR TITLE
MF-231: Fix select tag styling on the programs form

### DIFF
--- a/src/widgets/programs/programs-form.css
+++ b/src/widgets/programs/programs-form.css
@@ -43,13 +43,11 @@
 
 .programsInputContainer select {
   font-size: 1rem;
-  height: 2rem;
+  height: 2.625rem;
   color: var(--omrs-color-interaction);
-  text-align: center;
-  padding: 0.625rem;
+  padding: 0.5rem;
   border: 0.0625rem solid var(--omrs-color-ink-lowest-contrast);
   background-color: var(--omrs-color-ink-white);
-  border-radius: 4.5rem;
   min-width: 50%;
 }
 


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-231

A custom `height` property on the `select` tag is cutting the text off on some browsers. This ticket fixes that by adjusting the `height` property so it better accommodates the text inside the `select` tag.