### PR TITLE
MF-230: Set Location By Default When Starting a Visit

### DIFF
--- a/src/utils/use-session-user.tsx
+++ b/src/utils/use-session-user.tsx
@@ -8,11 +8,11 @@ export default function useSessionUser() {
   useEffect(() => {
     let currentUserSub: Subscription;
     if (sessionUser === null) {
-      currentUserSub = openmrsObservableFetch("/ws/rest/v1/session").subscribe(
-        (user: any) => {
-          setSessionUser(user.data);
-        }
-      );
+      currentUserSub = openmrsObservableFetch(
+        "/ws/rest/v1/appui/session"
+      ).subscribe((user: any) => {
+        setSessionUser(user.data);
+      });
     }
     return () => currentUserSub && currentUserSub.unsubscribe();
   }, [sessionUser]);


### PR DESCRIPTION
At the moment. when you select the new visit component select location select, the location dropdown is not auto-populated with the current session default location. [MF-230](https://issues.openmrs.org/projects/MF/issues/MF-230?filter=allissues) fixes this isssue