### PR TITLE
Consolidated use of react-router

### DIFF
--- a/src/ui-components/breadcrumbs/breadcrumbs.component.tsx
+++ b/src/ui-components/breadcrumbs/breadcrumbs.component.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from "react";
-import { useLocation } from "react-router";
-import styles from "./breadcrumbs.component.css";
-import { Link } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { getCurrentPatientUuid } from "@openmrs/esm-api";
 import { PatientChartRoute } from "../../widgets/level-two-routes.component";
+import styles from "./breadcrumbs.component.css";
 
 export default function Breadcrumbs(props: BreadcrumbsProps) {
   const { pathname } = useLocation();

--- a/src/widgets/level-two-routes.component.tsx
+++ b/src/widgets/level-two-routes.component.tsx
@@ -1,5 +1,5 @@
-import React, { FunctionComponent } from "react";
-import { match, Route } from "react-router";
+import React from "react";
+import { match, Route } from "react-router-dom";
 import AllergiesDetailedSummary from "./allergies/allergies-detailed-summary.component";
 import HeightAndWeightSummary from "../widgets/heightandweight/heightandweight-summary.component";
 import VitalsDetailedSummary from "../widgets/vitals/vitals-detailed-summary.component";

--- a/src/widgets/profile/contacts-card.component.tsx
+++ b/src/widgets/profile/contacts-card.component.tsx
@@ -3,7 +3,6 @@ import SummaryCard from "../../ui-components/cards/summary-card.component";
 import SummaryCardRow from "../../ui-components/cards/summary-card-row.component";
 import SummaryCardRowContent from "../../ui-components/cards/summary-card-row-content.component";
 import VerticalLabelValue from "../../ui-components/cards/vertical-label-value.component";
-import { match } from "react-router";
 
 export default function ContactsCard(props: ContactsCardProps) {
   function getAddress(address: fhir.Address) {

--- a/src/widgets/profile/profile-section.component.tsx
+++ b/src/widgets/profile/profile-section.component.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { match } from "react-router";
+import { match } from "react-router-dom";
 import styles from "./profile-section.component.css";
 import DemographicsCard from "./demographics-card.component";
 import IdentifiersCard from "./identifiers-card.component";

--- a/src/widgets/profile/relationships-card.component.tsx
+++ b/src/widgets/profile/relationships-card.component.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { match } from "react-router";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { fetchPatientRelationships } from "./relationships.resource";
 import SummaryCard from "../../ui-components/cards/summary-card.component";


### PR DESCRIPTION
I've seen that we sometimes use `react-router` as import instead of `react-router-dom`.

Quite often its just typings, however, if its actual functional this is a problem. Remember that `react-router` is not shared, however,  `react-router-dom` is.

Its just a tiny fix, but may be good in the future to be included in linting, too.