### PR TITLE
MF-234: Reusable RecordDetails component

### DIFF
--- a/__mocks__/dimensions.mock.ts
+++ b/__mocks__/dimensions.mock.ts
@@ -1,10 +1,6 @@
-import dayjs from "dayjs";
-
-const todaysDate = dayjs().format("YYYY-MM-DD");
-
 export const mockDimensionsResponse = [
   {
-    id: 1586949107000,
+    id: "bb1f0b1c-99c3-4be3-ac4b-c4086523ca5c",
     weight: 85,
     height: 165,
     date: "15-Apr 02:11 PM",
@@ -131,7 +127,7 @@ export const mockDimensionsResponse = [
     }
   },
   {
-    id: 1586174940000,
+    id: "51cd7805-1171-491c-823f-c67afce84614",
     weight: 80,
     height: 165,
     date: "06-Apr 03:09 PM",
@@ -258,7 +254,7 @@ export const mockDimensionsResponse = [
     }
   },
   {
-    id: 1586162873000,
+    id: "49fbba96-08eb-4b22-83f8-84753a15e70d",
     height: 186,
     date: "06-Apr 11:47 AM",
     bmi: null,
@@ -325,7 +321,7 @@ export const mockDimensionsResponse = [
     }
   },
   {
-    id: 1586162872000,
+    id: "e0f11a7e-31ab-4251-ac03-85a52be41c59",
     weight: 80,
     date: "06-Apr 11:47 AM",
     bmi: null,
@@ -392,7 +388,7 @@ export const mockDimensionsResponse = [
     }
   },
   {
-    id: 1585782029000,
+    id: "c0d589e9-a50a-4bd1-b1c2-fccfafcbb9d9",
     weight: 80,
     date: "02-Apr 02:00 AM",
     bmi: null,
@@ -459,7 +455,7 @@ export const mockDimensionsResponse = [
     }
   },
   {
-    id: 1585571936000,
+    id: "3c312c0c-a914-47b7-a2c1-ca0a5e40da5a",
     weight: 70,
     height: 185,
     date: "30-Mar 03:38 PM",

--- a/src/ui-components/cards/record-details-card.component.tsx
+++ b/src/ui-components/cards/record-details-card.component.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import SummaryCard from "../cards/summary-card.component";
+import styles from "./record-details-card.css";
+
+export default function RecordDetails(props: DetailsProps) {
+  return (
+    <SummaryCard
+      name="Details"
+      styles={{
+        width: "100%",
+        backgroundColor: "var(--omrs-color-bg-medium-contrast)"
+      }}
+    >
+      <div
+        style={props.styles}
+        className={`omrs-type-body-regular ${styles.detailsCard}`}
+      >
+        {props.children}
+      </div>
+    </SummaryCard>
+  );
+}
+
+type DetailsProps = {
+  children: React.ReactNode;
+  styles?: React.CSSProperties;
+};

--- a/src/ui-components/cards/record-details-card.css
+++ b/src/ui-components/cards/record-details-card.css
@@ -1,0 +1,8 @@
+.detailsCard {
+  margin: 0rem 1rem;
+}
+
+.detailsTable {
+  width: 100%;
+  margin-top: 1rem;
+}

--- a/src/widgets/allergies/allergy-record.component.tsx
+++ b/src/widgets/allergies/allergy-record.component.tsx
@@ -46,7 +46,7 @@ export default function AllergyRecord(props: AllergyRecordProps) {
       >
         <div
           className={`omrs-type-body-regular ${styles.allergyCard} ${
-            allergy.severity.display === "Severe"
+            allergy.severity.display === Severity.Severe
               ? `${styles.highSeverity}`
               : `${styles.lowSeverity}`
           }`}
@@ -67,16 +67,14 @@ export default function AllergyRecord(props: AllergyRecordProps) {
                 <td data-testid="severity">
                   <div
                     className={`${styles.centerItems} ${
-                      allergy.severity.display === "Severe" ? `omrs-bold` : ``
+                      styles.allergySeverity
+                    } ${
+                      allergy.severity.display === Severity.Severe
+                        ? `omrs-bold`
+                        : ``
                     }`}
-                    style={{
-                      textTransform: "uppercase",
-                      letterSpacing: "1px",
-                      lineHeight: "1rem",
-                      fontWeight: 500
-                    }}
                   >
-                    {allergy.severity.display === "Severe" && (
+                    {allergy.severity.display === Severity.Severe && (
                       <svg
                         className={`omrs-icon`}
                         fontSize={"15px"}
@@ -168,3 +166,9 @@ export default function AllergyRecord(props: AllergyRecordProps) {
 }
 
 type AllergyRecordProps = {};
+
+enum Severity {
+  Severe = "Severe",
+  Mild = "Mild",
+  Moderate = "Moderate"
+}

--- a/src/widgets/allergies/allergy-record.css
+++ b/src/widgets/allergies/allergy-record.css
@@ -6,6 +6,11 @@
   padding: 0.25rem 0.5rem 0 0.5rem;
 }
 
+.allergyContainer {
+  display: grid;
+  grid-gap: 25px;
+}
+
 .allergyCard {
   margin: 0rem 1rem;
 }
@@ -39,6 +44,13 @@
 
 .allergyFooter {
   padding: 0.625rem;
+}
+
+.allergySeverity {
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  line-height: 1rem;
+  font-weight: 500;
 }
 
 .centerItems {

--- a/src/widgets/allergies/allergy-record.test.tsx
+++ b/src/widgets/allergies/allergy-record.test.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import { getPatientAllergyByPatientUuid } from "./allergy-intolerance.resource";
 import { render, cleanup, wait } from "@testing-library/react";
-import { BrowserRouter, match } from "react-router-dom";
+import { BrowserRouter, match, useRouteMatch } from "react-router-dom";
 import AllergyRecord from "./allergy-record.component";
 import { useCurrentPatient } from "../../../__mocks__/openmrs-esm-api.mock";
 import { patient, mockAllergyResult } from "../../../__mocks__/allergy.mock";
-import { useRouteMatch } from "react-router";
 
 const mockGetPatientAllergyByPatientUuid = getPatientAllergyByPatientUuid as jest.Mock;
 const mockUseCurrentPatient = useCurrentPatient as jest.Mock;
@@ -19,8 +18,8 @@ jest.mock("@openmrs/esm-api", () => ({
   useCurrentPatient: jest.fn()
 }));
 
-jest.mock("react-router", () => ({
-  ...jest.requireActual("react-router"),
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
   useRouteMatch: jest.fn()
 }));
 

--- a/src/widgets/appointments/appointment-record.component.tsx
+++ b/src/widgets/appointments/appointment-record.component.tsx
@@ -9,6 +9,7 @@ import { useRouteMatch } from "react-router-dom";
 import VerticalLabelValue from "../../ui-components/cards/vertical-label-value.component";
 import styles from "./appointment-record.css";
 import { openWorkspaceTab } from "../shared-utils";
+import RecordDetails from "../../ui-components/cards/record-details-card.component";
 
 export default function AppointmentRecord(props: AppointmentRecordProps) {
   const [patientAppointment, setPatientAppointment] = useState(null);
@@ -35,87 +36,84 @@ export default function AppointmentRecord(props: AppointmentRecordProps) {
 
   return (
     <>
-      {patientAppointment && (
-        <SummaryCard
-          name="Appointment"
-          addComponent={AppointmentsForm}
-          showComponent={() =>
-            openWorkspaceTab(AppointmentsForm, "Appointment Form")
-          }
-        >
-          <table className={styles.appointmentRecordTable}>
-            <thead>
-              <tr>
-                <td colSpan={3} style={{ fontSize: "2rem" }}>
-                  {patientAppointment?.serviceType?.name}
-                </td>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>
-                  <VerticalLabelValue
-                    label="Date"
-                    value={dayjs(patientAppointment?.startDateTime).format(
-                      "YYYY-MMM-DD"
-                    )}
-                    valueStyles={{ fontFamily: "Work Sans" }}
-                  />
-                </td>
-                <td>
-                  <VerticalLabelValue
-                    label="Start Time"
-                    value={dayjs(patientAppointment?.startDateTime).format(
-                      "HH:mm A"
-                    )}
-                  />
-                </td>
-                <td>
-                  <VerticalLabelValue
-                    label="End Time"
-                    value={dayjs(patientAppointment?.endDateTime).format(
-                      "HH:mm A"
-                    )}
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td colSpan={3}>
-                  <VerticalLabelValue
-                    label="Comments"
-                    value={patientAppointment?.comments}
-                    valueStyles={{ whiteSpace: "pre-wrap" }}
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <VerticalLabelValue
-                    label="Service Type"
-                    value={patientAppointment?.serviceType?.name}
-                  />
-                </td>
-                <td>
-                  <VerticalLabelValue
-                    label="Appointment kind"
-                    value={patientAppointment?.appointmentKind}
-                  />
-                </td>
-                <td>
-                  <VerticalLabelValue
-                    label="Status"
-                    value={patientAppointment?.status}
-                  />
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </SummaryCard>
-      )}
-
-      {patientAppointment && (
-        <SummaryCard name="Details" styles={{ marginTop: "1.625rem" }}>
-          <div className={`omrs-type-body-regular`}>
+      {!!(patientAppointment && Object.entries(patientAppointment).length) && (
+        <div className={styles.appointmentContainer}>
+          <SummaryCard
+            name="Appointment"
+            addComponent={AppointmentsForm}
+            showComponent={() =>
+              openWorkspaceTab(AppointmentsForm, "Appointment Form")
+            }
+          >
+            <table className={styles.appointmentRecordTable}>
+              <thead>
+                <tr>
+                  <td colSpan={3} style={{ fontSize: "2rem" }}>
+                    {patientAppointment?.serviceType?.name}
+                  </td>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <VerticalLabelValue
+                      label="Date"
+                      value={dayjs(patientAppointment?.startDateTime).format(
+                        "YYYY-MMM-DD"
+                      )}
+                      valueStyles={{ fontFamily: "Work Sans" }}
+                    />
+                  </td>
+                  <td>
+                    <VerticalLabelValue
+                      label="Start Time"
+                      value={dayjs(patientAppointment?.startDateTime).format(
+                        "HH:mm A"
+                      )}
+                    />
+                  </td>
+                  <td>
+                    <VerticalLabelValue
+                      label="End Time"
+                      value={dayjs(patientAppointment?.endDateTime).format(
+                        "HH:mm A"
+                      )}
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td colSpan={3}>
+                    <VerticalLabelValue
+                      label="Comments"
+                      value={patientAppointment?.comments}
+                      valueStyles={{ whiteSpace: "pre-wrap" }}
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <VerticalLabelValue
+                      label="Service Type"
+                      value={patientAppointment?.serviceType?.name}
+                    />
+                  </td>
+                  <td>
+                    <VerticalLabelValue
+                      label="Appointment kind"
+                      value={patientAppointment?.appointmentKind}
+                    />
+                  </td>
+                  <td>
+                    <VerticalLabelValue
+                      label="Status"
+                      value={patientAppointment?.status}
+                    />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </SummaryCard>
+          <RecordDetails>
             <table className={styles.appointmentRecordTable}>
               <thead className={styles.appointmentRecordTableHeader}>
                 <tr>
@@ -142,8 +140,8 @@ export default function AppointmentRecord(props: AppointmentRecordProps) {
                 </tr>
               </tbody>
             </table>
-          </div>
-        </SummaryCard>
+          </RecordDetails>
+        </div>
       )}
     </>
   );

--- a/src/widgets/appointments/appointment-record.css
+++ b/src/widgets/appointments/appointment-record.css
@@ -1,3 +1,8 @@
+.appointmentContainer {
+  display: grid;
+  grid-gap: 25px;
+}
+
 .appointmentRecordTable {
   width: 100%;
   text-align: left;

--- a/src/widgets/appointments/appointment-record.test.tsx
+++ b/src/widgets/appointments/appointment-record.test.tsx
@@ -6,8 +6,7 @@ import {
   wait,
   fireEvent
 } from "@testing-library/react";
-import { BrowserRouter, match } from "react-router-dom";
-import { useRouteMatch } from "react-router";
+import { BrowserRouter, match, useRouteMatch } from "react-router-dom";
 import AppointmentRecord from "./appointment-record.component";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import {
@@ -28,8 +27,8 @@ jest.mock("@openmrs/esm-api", () => ({
   useCurrentPatient: jest.fn()
 }));
 
-jest.mock("react-router", () => ({
-  ...jest.requireActual("react-router"),
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
   useRouteMatch: jest.fn()
 }));
 

--- a/src/widgets/conditions/condition-record.component.tsx
+++ b/src/widgets/conditions/condition-record.component.tsx
@@ -8,6 +8,7 @@ import styles from "./condition-record.css";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import { ConditionsForm } from "./conditions-form.component";
 import { openWorkspaceTab } from "../shared-utils";
+import RecordDetails from "../../ui-components/cards/record-details-card.component";
 
 export default function ConditionRecord(props: ConditionRecordProps) {
   const [patientCondition, setPatientCondition] = useState(null);
@@ -24,92 +25,72 @@ export default function ConditionRecord(props: ConditionRecordProps) {
     }
   }, [isLoadingPatient, patient, match.params]);
 
-  function displayCondition() {
-    return (
-      <>
-        <SummaryCard
-          name="Condition"
-          styles={{ width: "100%" }}
-          editComponent={ConditionsForm}
-          showComponent={() => {
-            openWorkspaceTab(ConditionsForm, "Edit Conditions", {
-              conditionUuid: patientCondition?.id,
-              conditionName: patientCondition?.code?.text,
-              clinicalStatus: patientCondition?.clinicalStatus,
-              onsetDateTime: patientCondition?.onsetDateTime
-            });
-          }}
-        >
-          <div className={`omrs-type-body-regular ${styles.conditionCard}`}>
-            <div>
-              <p className="omrs-type-title-3">
-                {patientCondition?.code?.text}
-              </p>
+  return (
+    <>
+      {!!(patientCondition && Object.entries(patientCondition).length) && (
+        <div className={styles.conditionContainer}>
+          <SummaryCard
+            name="Condition"
+            styles={{ width: "100%" }}
+            editComponent={ConditionsForm}
+            showComponent={() => {
+              openWorkspaceTab(ConditionsForm, "Edit Conditions", {
+                conditionUuid: patientCondition?.id,
+                conditionName: patientCondition?.code?.text,
+                clinicalStatus: patientCondition?.clinicalStatus,
+                onsetDateTime: patientCondition?.onsetDateTime
+              });
+            }}
+          >
+            <div className={`omrs-type-body-regular ${styles.conditionCard}`}>
+              <div>
+                <p className="omrs-type-title-3">
+                  {patientCondition?.code?.text}
+                </p>
+              </div>
+              <table className={styles.conditionTable}>
+                <thead>
+                  <tr>
+                    <td>Onset date</td>
+                    <td>Status</td>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      {dayjs(patientCondition?.onsetDateTime).format(
+                        "MMM-YYYY"
+                      )}
+                    </td>
+                    <td>{capitalize(patientCondition?.clinicalStatus)}</td>
+                  </tr>
+                </tbody>
+              </table>
             </div>
+          </SummaryCard>
+          <RecordDetails>
             <table className={styles.conditionTable}>
               <thead>
                 <tr>
-                  <td>Onset date</td>
-                  <td>Status</td>
+                  <td>Last updated</td>
+                  <td>Last updated by</td>
+                  <td>Last updated location</td>
                 </tr>
               </thead>
               <tbody>
                 <tr>
                   <td>
-                    {dayjs(patientCondition?.onsetDateTime).format("MMM-YYYY")}
+                    {dayjs(patientCondition?.lastUpdated).format("DD-MMM-YYYY")}
                   </td>
-                  <td>{capitalize(patientCondition?.clinicalStatus)}</td>
+                  <td>{patientCondition?.lastUpdatedBy}</td>
+                  <td>{patientCondition?.lastUpdatedLocation}</td>
                 </tr>
               </tbody>
             </table>
-          </div>
-        </SummaryCard>
-      </>
-    );
-  }
-
-  function displayDetails() {
-    return (
-      <SummaryCard
-        name="Details"
-        styles={{
-          width: "100%",
-          backgroundColor: "var(--omrs-color-bg-medium-contrast)"
-        }}
-      >
-        <div className={`omrs-type-body-regular ${styles.conditionCard}`}>
-          <table className={styles.conditionTable}>
-            <thead>
-              <tr>
-                <td>Last updated</td>
-                <td>Last updated by</td>
-                <td>Last updated location</td>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>
-                  {dayjs(patientCondition?.lastUpdated).format("DD-MMM-YYYY")}
-                </td>
-                <td>{patientCondition?.lastUpdatedBy}</td>
-                <td>{patientCondition?.lastUpdatedLocation}</td>
-              </tr>
-            </tbody>
-          </table>
+          </RecordDetails>
         </div>
-      </SummaryCard>
-    );
-  }
-
-  return (
-    <div className={styles.conditionContainer}>
-      {patientCondition && (
-        <div className={styles.conditionSummary}>{displayCondition()}</div>
       )}
-      {patientCondition && (
-        <div className={styles.conditionSummary}>{displayDetails()}</div>
-      )}
-    </div>
+    </>
   );
 }
 

--- a/src/widgets/heightandweight/heightandweight-record.css
+++ b/src/widgets/heightandweight/heightandweight-record.css
@@ -1,21 +1,10 @@
-:global(.omrs-breakpoint-gt-phone) .heightAndWeightDetailedSummary {
-  display: flex;
-  flex-wrap: wrap;
+.dimensionsContainer {
+  display: grid;
+  grid-gap: 25px;
 }
 
-:global(.omrs-breakpoint-lt-tablet) .heightAndWeightDetailedSummary {
-  display: flex;
-  flex-wrap: wrap;
-  margin: 0.25rem 0.5rem 0 0.5rem;
-}
-
-:global(.omrs-breakpoint-lt-tablet) .heightAndWeightContainer {
-  display: flex;
-  justify-content: flex-start;
-}
-:global(.omrs-breakpoint-gt-phone) .heightAndWeightContainer {
-  display: flex;
-  margin: "0rem 0rem 0rem 4.875rem";
+.dimensionsCard {
+  margin: 0rem 1rem;
 }
 
 .summaryTable {

--- a/src/widgets/heightandweight/heightandweight.resource.ts
+++ b/src/widgets/heightandweight/heightandweight.resource.ts
@@ -43,7 +43,7 @@ function formatDimensions(weights, heights) {
     const weight = weights.find(weight => weight.issued === date);
     const height = heights.find(height => height.issued === date);
     return {
-      id: new Date(date).getTime(),
+      id: weight && weight?.encounter?.reference?.replace("Encounter/", ""),
       weight: weight ? weight.valueQuantity.value : weight,
       height: height ? height.valueQuantity.value : height,
       date: formatDate(date),

--- a/src/widgets/medications/medication-record.component.tsx
+++ b/src/widgets/medications/medication-record.component.tsx
@@ -9,6 +9,7 @@ import { formatDuration, getDosage } from "./medication-orders-utils";
 import styles from "./medication-record.css";
 import MedicationOrderBasket from "./medication-order-basket.component";
 import { openWorkspaceTab } from "../shared-utils";
+import RecordDetails from "../../ui-components/cards/record-details-card.component";
 
 export default function MedicationRecord(props: MedicationRecordProps) {
   const [patientMedication, setPatientMedication] = React.useState(null);
@@ -26,18 +27,18 @@ export default function MedicationRecord(props: MedicationRecordProps) {
     }
   }, [isLoadingPatient, patient, match.params]);
 
-  function displayMedication() {
-    return (
-      patientMedication && (
-        <>
+  return (
+    <div className={styles.medicationContainer}>
+      {!!(patientMedication && Object.entries(patientMedication)) && (
+        <div className={styles.medicationSummary}>
           <SummaryCard
             name="Medication"
             styles={{ width: "100%" }}
             editComponent={MedicationOrderBasket}
             showComponent={() =>
               openWorkspaceTab(MedicationOrderBasket, "Edit Medication Order", {
-                drugName: patientMedication.drug.display,
-                orderUuid: patientMedication.uuid,
+                drugName: patientMedication?.drug?.display,
+                orderUuid: patientMedication?.uuid,
                 action: "REVISE"
               })
             }
@@ -47,7 +48,7 @@ export default function MedicationRecord(props: MedicationRecordProps) {
                 className="omrs-type-title-3"
                 style={{ color: "var(--omrs-color-ink-medium-contrast)" }}
               >
-                {patientMedication.drug.display}
+                {patientMedication?.drug?.display}
               </p>
               <div className={styles.medicationSummaryLine}>
                 <span
@@ -56,7 +57,7 @@ export default function MedicationRecord(props: MedicationRecordProps) {
                     color: "var(--omrs-color-ink-high-contrast)"
                   }}
                 >
-                  {patientMedication.drug.display}
+                  {patientMedication?.drug?.display}
                 </span>{" "}
                 &mdash;{" "}
                 <span>
@@ -89,7 +90,7 @@ export default function MedicationRecord(props: MedicationRecordProps) {
                   <tr>
                     <td style={{ letterSpacing: "0.028rem" }}>
                       {patientMedication.dateActivated
-                        ? dayjs(patientMedication.dateActivated).format(
+                        ? dayjs(patientMedication?.dateActivated).format(
                             "dddd DD-MMM-YYYY"
                           )
                         : "—"}
@@ -102,14 +103,14 @@ export default function MedicationRecord(props: MedicationRecordProps) {
                   </tr>
                   <tr>
                     <td>
-                      {patientMedication.dateStopped
-                        ? dayjs(patientMedication.dateStopped).format(
+                      {patientMedication?.dateStopped
+                        ? dayjs(patientMedication?.dateStopped).format(
                             "dddd DD-MMM-YYYY"
                           )
                         : "—"}
                     </td>
                     <td>
-                      {patientMedication.dosingInstructions
+                      {patientMedication?.dosingInstructions
                         ? patientMedication.dosingInstructions
                         : "none"}
                     </td>
@@ -124,59 +125,35 @@ export default function MedicationRecord(props: MedicationRecordProps) {
                     <th>Total number of refills</th>
                   </tr>
                   <tr>
-                    <td>{patientMedication.numRefills}</td>
+                    <td>{patientMedication?.numRefills}</td>
                   </tr>
                 </tbody>
               </table>
             </div>
           </SummaryCard>
-        </>
-      )
-    );
-  }
-
-  function displayDetails() {
-    return (
-      <SummaryCard
-        name="Details"
-        styles={{
-          width: "100%",
-          backgroundColor: "var(--omrs-color-bg-medium-contrast)"
-        }}
-      >
-        <div className={`omrs-type-body-regular ${styles.medicationCard}`}>
-          <table className={styles.medicationDetailsTable}>
-            <thead>
-              <tr>
-                <th>Last updated</th>
-                <th>Last updated by</th>
-                <th>Last updated location</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td style={{ fontFamily: "Work Sans" }}>
-                  {dayjs(patientMedication?.dateActivated).format(
-                    "DD-MMM-YYYY"
-                  )}
-                </td>
-                <td>{patientMedication?.orderer?.person?.display}</td>
-                <td>{`Location Test`}</td>
-              </tr>
-            </tbody>
-          </table>
+          <RecordDetails>
+            <table className={styles.medicationDetailsTable}>
+              <thead>
+                <tr>
+                  <th>Last updated</th>
+                  <th>Last updated by</th>
+                  <th>Last updated location</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td style={{ fontFamily: "Work Sans" }}>
+                    {dayjs(patientMedication?.dateActivated).format(
+                      "DD-MMM-YYYY"
+                    )}
+                  </td>
+                  <td>{patientMedication?.orderer?.person?.display}</td>
+                  <td>{`Location Test`}</td>
+                </tr>
+              </tbody>
+            </table>
+          </RecordDetails>
         </div>
-      </SummaryCard>
-    );
-  }
-
-  return (
-    <div className={styles.medicationContainer}>
-      {patientMedication && (
-        <div className={styles.medicationSummary}>{displayMedication()}</div>
-      )}
-      {patientMedication && (
-        <div className={styles.medicationSummary}>{displayDetails()}</div>
       )}
     </div>
   );

--- a/src/widgets/medications/medication-record.test.tsx
+++ b/src/widgets/medications/medication-record.test.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { render, cleanup, wait } from "@testing-library/react";
-import { match, useRouteMatch } from "react-router";
 import MedicationRecord from "./medication-record.component";
-import { BrowserRouter } from "react-router-dom";
+import { match, useRouteMatch, BrowserRouter } from "react-router-dom";
 import { useCurrentPatient, openmrsFetch } from "@openmrs/esm-api";
 import { mockPatient } from "../../../__mocks__/patient.mock";
 import { mockMedicationOrderByUuidResponse } from "../../../__mocks__/medication.mock";
@@ -16,8 +15,8 @@ jest.mock("@openmrs/esm-api", () => ({
   openmrsFetch: jest.fn()
 }));
 
-jest.mock("react-router", () => ({
-  ...jest.requireActual("react-router"),
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
   useRouteMatch: jest.fn()
 }));
 

--- a/src/widgets/notes/note-record.component.tsx
+++ b/src/widgets/notes/note-record.component.tsx
@@ -6,6 +6,7 @@ import { createErrorHandler } from "@openmrs/esm-error-handling";
 import styles from "./note-record.css";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import dayjs from "dayjs";
+import RecordDetails from "../../ui-components/cards/record-details-card.component";
 
 export default function NoteRecord(props: NoteRecordProps) {
   const [note, setNote] = useState(null);
@@ -22,10 +23,10 @@ export default function NoteRecord(props: NoteRecordProps) {
     }
   }, [isLoadingPatient, patient, match.params]);
 
-  function displayNote() {
-    return (
-      <>
-        {note && (
+  return (
+    <>
+      {!!(note && Object.entries(note).length) && (
+        <div className={styles.noteContainer}>
           <SummaryCard name="Note" styles={{ width: "100%" }}>
             <div className={`omrs-type-body-regular ${styles.noteCard}`}>
               <div>
@@ -51,23 +52,8 @@ export default function NoteRecord(props: NoteRecordProps) {
               </table>
             </div>
           </SummaryCard>
-        )}
-      </>
-    );
-  }
-
-  function displayNoteDetails() {
-    return (
-      <>
-        {note.obs && note.obs.length && (
-          <SummaryCard
-            name="Details"
-            styles={{
-              width: "100%",
-              backgroundColor: "var(--omrs-color-bg-medium-contrast)"
-            }}
-          >
-            <div className={`omrs-type-body-regular ${styles.noteCard}`}>
+          {note.obs && note.obs.length && (
+            <RecordDetails>
               {note.obs.map(ob => {
                 return (
                   <Fragment key={ob.uuid}>
@@ -75,22 +61,11 @@ export default function NoteRecord(props: NoteRecordProps) {
                   </Fragment>
                 );
               })}
-            </div>
-          </SummaryCard>
-        )}
-      </>
-    );
-  }
-
-  return (
-    <div className={styles.noteContainer}>
-      {note && <div className={styles.noteSummary}>{displayNote()}</div>}
-      {note && note.obs.length ? (
-        <div className={styles.noteSummary}>{displayNoteDetails()}</div>
-      ) : (
-        ""
+            </RecordDetails>
+          )}
+        </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/src/widgets/programs/program-record.component.tsx
+++ b/src/widgets/programs/program-record.component.tsx
@@ -29,7 +29,7 @@ export default function ProgramRecord(props: ProgramRecordProps) {
 
   return (
     <>
-      {patientProgram && (
+      {!!(patientProgram && Object.entries(patientProgram).length) && (
         <div className={styles.programSummary}>
           <SummaryCard
             name="Program"

--- a/src/widgets/vitals/vital-record.component.tsx
+++ b/src/widgets/vitals/vital-record.component.tsx
@@ -11,13 +11,11 @@ import SummaryCard from "../../ui-components/cards/summary-card.component";
 import dayjs from "dayjs";
 import VitalsForm from "./vitals-form.component";
 import { openWorkspaceTab } from "../shared-utils";
-import { useTranslation } from "react-i18next";
 
 export default function VitalRecord(props: VitalRecordProps) {
   const [vitalSigns, setVitalSigns] = useState<PatientVitals>(null);
   const [isLoadingPatient, patient, patientUuid] = useCurrentPatient();
   const match = useRouteMatch();
-  const { t } = useTranslation();
 
   useEffect(() => {
     if (!isLoadingPatient && patientUuid && match.params) {
@@ -34,16 +32,12 @@ export default function VitalRecord(props: VitalRecordProps) {
 
   return (
     <>
-      {vitalSigns && (
+      {!!(vitalSigns && Object.entries(vitalSigns).length) && (
         <SummaryCard
-          name={t("Vital", "Vital")}
+          name="Vital"
+          showComponent={() => openWorkspaceTab(VitalsForm, "Vitals Form")}
+          addComponent={VitalsForm}
           styles={{ width: "100%" }}
-          editComponent={VitalsForm}
-          showComponent={() =>
-            openWorkspaceTab(VitalsForm, t("editVitals", "Edit Vitals"), {
-              vitalUuid: match.params["vitalUuid"]
-            })
-          }
         >
           <div className={`omrs-type-body-regular ${styles.vitalCard}`}>
             <table className={styles.vitalTable}>

--- a/src/widgets/vitals/vital-record.test.tsx
+++ b/src/widgets/vitals/vital-record.test.tsx
@@ -1,13 +1,12 @@
 import React from "react";
 import { cleanup, render, wait } from "@testing-library/react";
-import { BrowserRouter, match } from "react-router-dom";
+import { BrowserRouter, match, useRouteMatch } from "react-router-dom";
 import VitalRecord from "./vital-record.component";
 import { mockPatient } from "../../../__mocks__/patient.mock";
 import { useCurrentPatient } from "../../../__mocks__/openmrs-esm-api.mock";
 import { mockVitalSigns, mockVitalData } from "../../../__mocks__/vitals.mock";
 import { performPatientsVitalsSearch } from "./vitals-card.resource";
 import { of } from "rxjs/internal/observable/of";
-import { useRouteMatch } from "react-router";
 
 const mockUseCurrentPatient = useCurrentPatient as jest.Mock;
 const mockUseRouteMatch = useRouteMatch as jest.Mock;
@@ -21,8 +20,8 @@ jest.mock("./vitals-card.resource", () => ({
   performPatientsVitalsSearch: jest.fn()
 }));
 
-jest.mock("react-router", () => ({
-  ...jest.requireActual("react-router"),
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
   useRouteMatch: jest.fn()
 }));
 


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-234

A pattern is being repeated across the widget record components where a summary card is being rendered as a details view. This view typically contains a table containing arbitrary data with the card header 'Details'. This logic should be extracted into its own reusable component.

<img width="564" alt="Screenshot 2020-05-28 at 16 17 34" src="https://user-images.githubusercontent.com/8509731/83172410-30ebb300-a120-11ea-9f66-9d44805317dc.png">

Apologies for the huge PR - some issues cropped up in the process of refactoring - for example, the logic being used to determine the `HeightAndWeight` record to load after clicking on a record in the `HeightAndWeightSummary` component wasn't working reliably - the check was returning undefined every time. I've changed it so that it compares records by their `id`s and that the individual obs would be grouped by their encounter id. This works reliably. 