### PR TITLE
MF-219: Add EmptyState component translations

### DIFF
--- a/src/ui-components/empty-state/empty-state.component.tsx
+++ b/src/ui-components/empty-state/empty-state.component.tsx
@@ -3,6 +3,7 @@ import SummaryCard from "../cards/summary-card.component";
 import { DataCaptureComponentProps } from "../../widgets/shared-utils";
 import styles from "./empty-state.css";
 import { match } from "react-router-dom";
+import { Trans } from "react-i18next";
 
 export default function EmptyState(props: EmptyStateProps) {
   return (
@@ -15,7 +16,14 @@ export default function EmptyState(props: EmptyStateProps) {
         style={props.styles}
         className={`omrs-medium ${styles.emptyStateText}`}
       >
-        <p className="omrs-type-body-regular">{props.displayText}</p>
+        <p className="omrs-type-body-regular">
+          <Trans
+            i18nKey="emptyStateText"
+            values={{ displayText: props.displayText }}
+          >
+            This patient has no {props.displayText} recorded in the system.
+          </Trans>
+        </p>
       </div>
     </SummaryCard>
   );

--- a/src/widgets/allergies/allergies-overview.component.tsx
+++ b/src/widgets/allergies/allergies-overview.component.tsx
@@ -10,6 +10,7 @@ import { useCurrentPatient } from "@openmrs/esm-api";
 import AllergyForm from "./allergy-form.component";
 import { openWorkspaceTab } from "../shared-utils";
 import useChartBasePath from "../../utils/use-chart-base";
+import { useTranslation } from "react-i18next";
 
 export default function AllergiesOverview(props: AllergiesOverviewProps) {
   const [patientAllergies, setPatientAllergies] = React.useState(null);
@@ -21,6 +22,7 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
   ] = useCurrentPatient();
   const chartBasePath = useChartBasePath();
   const allergiesPath = chartBasePath + "/" + props.basePath;
+  const { t } = useTranslation();
 
   React.useEffect(() => {
     if (patient) {
@@ -36,14 +38,14 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
 
   return (
     <>
-      {patientAllergies && patientAllergies.total > 0 ? (
+      {patientAllergies?.total > 0 ? (
         <SummaryCard
-          name="Allergies"
+          name={t("Allergies")}
           styles={{ margin: "1.25rem, 1.5rem" }}
           link={`/patient/${patientUuid}/chart/allergies`}
           addComponent={AllergyForm}
           showComponent={() => {
-            openWorkspaceTab(AllergyForm, "Allergy Form", {
+            openWorkspaceTab(AllergyForm, `${t("Allergy Form")}`, {
               allergyUuid: null
             });
           }}
@@ -74,10 +76,12 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
         </SummaryCard>
       ) : (
         <EmptyState
-          showComponent={() => openWorkspaceTab(AllergyForm, "Allergy Form")}
+          showComponent={() =>
+            openWorkspaceTab(AllergyForm, `${t("Allergy Form")}`)
+          }
           addComponent={AllergyForm}
-          name="Allergies"
-          displayText="This patient has no allergy intolerances recorded in the system."
+          name={t("Allergies")}
+          displayText={t("allergy intolerances")}
         />
       )}
     </>

--- a/src/widgets/appointments/appointments-overview.component.tsx
+++ b/src/widgets/appointments/appointments-overview.component.tsx
@@ -10,6 +10,7 @@ import AppointmentsForm from "./appointments-form.component";
 import { Link } from "react-router-dom";
 import { openWorkspaceTab } from "../shared-utils";
 import useChartBasePath from "../../utils/use-chart-base";
+import { useTranslation } from "react-i18next";
 
 export default function AppointmentsOverview(props: AppointmentOverviewProps) {
   const [patientAppointments, setPatientAppointments] = React.useState([]);
@@ -22,6 +23,7 @@ export default function AppointmentsOverview(props: AppointmentOverviewProps) {
   const startDate = dayjs().format();
   const chartBasePath = useChartBasePath();
   const appointmentsPath = chartBasePath + "/" + props.basePath;
+  const { t } = useTranslation();
 
   React.useEffect(() => {
     if (!isLoadingPatient && patientUuid) {
@@ -37,9 +39,9 @@ export default function AppointmentsOverview(props: AppointmentOverviewProps) {
 
   return (
     <>
-      {patientAppointments && patientAppointments.length > 0 ? (
+      {patientAppointments?.length > 0 ? (
         <SummaryCard
-          name="Appointments"
+          name={t("Appointments")}
           link={appointmentsPath}
           showComponent={() =>
             openWorkspaceTab(AppointmentsForm, "Appointments Form")
@@ -84,11 +86,11 @@ export default function AppointmentsOverview(props: AppointmentOverviewProps) {
       ) : (
         <EmptyState
           showComponent={() =>
-            openWorkspaceTab(AppointmentsForm, "Appointments Form")
+            openWorkspaceTab(AppointmentsForm, `${t("Appointments Form")}`)
           }
           addComponent={AppointmentsForm}
-          name="Appointments"
-          displayText="This patient has no appointments recorded in the system."
+          name={t("Appointments")}
+          displayText={t("appointments")}
         />
       )}
     </>

--- a/src/widgets/conditions/conditions-overview.component.tsx
+++ b/src/widgets/conditions/conditions-overview.component.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 import { ConditionsForm } from "./conditions-form.component";
 import { openWorkspaceTab } from "../shared-utils";
 import useChartBasePath from "../../utils/use-chart-base";
+import EmptyState from "../../ui-components/empty-state/empty-state.component";
 
 export default function ConditionsOverview(props: ConditionsOverviewProps) {
   const [patientConditions, setPatientConditions] = useState(null);
@@ -21,9 +22,9 @@ export default function ConditionsOverview(props: ConditionsOverviewProps) {
     patientUuid,
     patientErr
   ] = useCurrentPatient();
-  const { t } = useTranslation();
   const chartBasePath = useChartBasePath();
-  const conditionsPath = `${chartBasePath}/${props.basePath}`;
+  const conditionsPath = chartBasePath + "/" + props.basePath;
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (patient) {
@@ -40,49 +41,63 @@ export default function ConditionsOverview(props: ConditionsOverviewProps) {
   }, [patient]);
 
   return (
-    <SummaryCard
-      name={t("Conditions", "Conditions")}
-      styles={{ margin: "1.25rem, 1.5rem" }}
-      link={conditionsPath}
-      addComponent={ConditionsForm}
-      showComponent={() => openWorkspaceTab(ConditionsForm, "Conditions Form")}
-    >
-      <SummaryCardRow>
-        <SummaryCardRowContent>
-          <HorizontalLabelValue
-            label={t("Active Conditions", "Active Conditions")}
-            labelStyles={{
-              color: "var(--omrs-color-ink-medium-contrast)",
-              fontFamily: "Work Sans"
-            }}
-            value={t("Since", "Since")}
-            valueStyles={{
-              color: "var(--omrs-color-ink-medium-contrast)",
-              fontFamily: "Work Sans"
-            }}
-          />
-        </SummaryCardRowContent>
-      </SummaryCardRow>
-      {patientConditions &&
-        patientConditions.entry.map(condition => {
-          return (
-            <SummaryCardRow
-              key={condition.resource.id}
-              linkTo={`${conditionsPath}/details/${condition.resource.id}`}
-            >
+    <>
+      {patientConditions?.entry?.length > 0 ? (
+        <SummaryCard
+          name={t("Conditions")}
+          styles={{ margin: "1.25rem, 1.5rem" }}
+          link={conditionsPath}
+          addComponent={ConditionsForm}
+          showComponent={() =>
+            openWorkspaceTab(ConditionsForm, `${t("Conditions Form")}`)
+          }
+        >
+          <SummaryCardRow>
+            <SummaryCardRowContent>
               <HorizontalLabelValue
-                label={condition.resource.code.text}
-                labelStyles={{ fontWeight: 500 }}
-                value={dayjs(condition.resource.onsetDateTime).format(
-                  "MMM-YYYY"
-                )}
-                valueStyles={{ fontFamily: "Work Sans" }}
+                label="Active Conditions"
+                labelStyles={{
+                  color: "var(--omrs-color-ink-medium-contrast)",
+                  fontFamily: "Work Sans"
+                }}
+                value="Since"
+                valueStyles={{
+                  color: "var(--omrs-color-ink-medium-contrast)",
+                  fontFamily: "Work Sans"
+                }}
               />
-            </SummaryCardRow>
-          );
-        })}
-      <SummaryCardFooter linkTo={`${conditionsPath}`} />
-    </SummaryCard>
+            </SummaryCardRowContent>
+          </SummaryCardRow>
+          {patientConditions?.entry?.map(condition => {
+            return (
+              <SummaryCardRow
+                key={condition?.resource?.id}
+                linkTo={`${conditionsPath}/${condition?.resource?.id}`}
+              >
+                <HorizontalLabelValue
+                  label={condition?.resource?.code?.text}
+                  labelStyles={{ fontWeight: 500 }}
+                  value={dayjs(condition?.resource?.onsetDateTime).format(
+                    "MMM-YYYY"
+                  )}
+                  valueStyles={{ fontFamily: "Work Sans" }}
+                />
+              </SummaryCardRow>
+            );
+          })}
+          <SummaryCardFooter linkTo={`${conditionsPath}`} />
+        </SummaryCard>
+      ) : (
+        <EmptyState
+          showComponent={() =>
+            openWorkspaceTab(ConditionsForm, `${t("Conditions Form")}`)
+          }
+          addComponent={ConditionsForm}
+          name={t("Conditions")}
+          displayText={t("conditions")}
+        />
+      )}
+    </>
   );
 }
 

--- a/src/widgets/heightandweight/heightandweight-overview.component.tsx
+++ b/src/widgets/heightandweight/heightandweight-overview.component.tsx
@@ -13,6 +13,7 @@ import VitalsForm from "../vitals/vitals-form.component";
 import withConfig from "../../with-config";
 import styles from "./heightandweight-overview.css";
 import { getDimensions } from "./heightandweight.resource";
+import { useTranslation } from "react-i18next";
 
 function HeightAndWeightOverview(props: HeightAndWeightOverviewProps) {
   const [dimensions, setDimensions] = React.useState([]);
@@ -25,6 +26,7 @@ function HeightAndWeightOverview(props: HeightAndWeightOverviewProps) {
   ] = useCurrentPatient();
   const chartBasePath = useChartBasePath();
   const heightweightPath = chartBasePath + "/" + props.basePath;
+  const { t } = useTranslation();
 
   React.useEffect(() => {
     if (patientUuid) {
@@ -48,9 +50,11 @@ function HeightAndWeightOverview(props: HeightAndWeightOverviewProps) {
     <>
       {dimensions.length > 0 ? (
         <SummaryCard
-          name="Height & Weight"
+          name={t("Height & Weight")}
           link={`${heightweightPath}`}
-          showComponent={() => openWorkspaceTab(VitalsForm, "Vitals Form")}
+          showComponent={() =>
+            openWorkspaceTab(VitalsForm, `${t("Vitals Form")}`)
+          }
           addComponent={VitalsForm}
         >
           <SummaryCardRow>
@@ -119,10 +123,12 @@ function HeightAndWeightOverview(props: HeightAndWeightOverviewProps) {
         </SummaryCard>
       ) : (
         <EmptyState
-          showComponent={() => openWorkspaceTab(VitalsForm, "Vitals Form")}
+          showComponent={() =>
+            openWorkspaceTab(VitalsForm, `${t("Vitals Form")}`)
+          }
           addComponent={VitalsForm}
-          name="Height & Weight"
-          displayText="This patient has no dimensions recorded in the system."
+          name={t("Height & Weight")}
+          displayText={t("dimensions")}
         />
       )}
     </>

--- a/src/widgets/medications/medications-overview.component.tsx
+++ b/src/widgets/medications/medications-overview.component.tsx
@@ -43,13 +43,13 @@ export default function MedicationsOverview(props: MedicationsOverviewProps) {
 
   return (
     <>
-      {patientMedications && patientMedications.length > 0 ? (
+      {patientMedications?.length > 0 ? (
         <SummaryCard
-          name={t("Active Medications", "Active Medications")}
+          name={t("Active Medications")}
           styles={{ width: "100%" }}
           link={`${props.basePath}`}
           showComponent={() =>
-            openWorkspaceTab(MedicationOrderBasket, "Medication Order")
+            openWorkspaceTab(MedicationOrderBasket, `${t("Medication Order")}`)
           }
         >
           <SummaryCardRow>
@@ -153,11 +153,11 @@ export default function MedicationsOverview(props: MedicationsOverviewProps) {
       ) : (
         <EmptyState
           showComponent={() =>
-            openWorkspaceTab(MedicationOrderBasket, "Medication Order")
+            openWorkspaceTab(MedicationOrderBasket, `${t("Medication Order")}`)
           }
           addComponent={MedicationOrderBasket}
-          name="Active Medications"
-          displayText="This patient has no active medications recorded in the system."
+          name={t("Active Medications")}
+          displayText={t("active medications")}
         />
       )}
     </>

--- a/src/widgets/notes/notes-overview.component.tsx
+++ b/src/widgets/notes/notes-overview.component.tsx
@@ -1,20 +1,18 @@
 import React from "react";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
-import {
-  getEncounters,
-  getEncounterObservableRESTAPI
-} from "./encounter.resource";
+import { getEncounterObservableRESTAPI } from "./encounter.resource";
 import styles from "./notes-overview.css";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import { Link } from "react-router-dom";
-import { getNotes, formatNotesDate, getAuthorName } from "./notes-helper";
+import { formatNotesDate } from "./notes-helper";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import SummaryCardFooter from "../../ui-components/cards/summary-card-footer.component";
 import EmptyState from "../../ui-components/empty-state/empty-state.component";
 import { useTranslation } from "react-i18next";
-import { isEmpty } from "lodash-es";
 import useChartBasePath from "../../utils/use-chart-base";
 import { PatientNotes } from "../types";
+import { openWorkspaceTab } from "../shared-utils";
+import VisitNotes from "./visit-note.component";
 
 export default function NotesOverview(props: NotesOverviewProps) {
   const [patientNotes, setPatientNotes] = React.useState<Array<PatientNotes>>();
@@ -24,10 +22,9 @@ export default function NotesOverview(props: NotesOverviewProps) {
     patientUuid,
     patientErr
   ] = useCurrentPatient();
-
-  const { t } = useTranslation();
   const chartBasePath = useChartBasePath();
   const notesPath = chartBasePath + "/" + props.basePath;
+  const { t } = useTranslation();
 
   React.useEffect(() => {
     if (patient && patientUuid) {
@@ -41,9 +38,13 @@ export default function NotesOverview(props: NotesOverviewProps) {
 
   return (
     <>
-      {patientNotes && patientNotes.length > 0 ? (
+      {patientNotes?.length > 0 ? (
         <SummaryCard
-          name={t("Notes", "Notes")}
+          name={t("Notes")}
+          showComponent={() =>
+            openWorkspaceTab(VisitNotes, `${t("Visit Notes")}`)
+          }
+          addComponent={VisitNotes}
           styles={{ width: "100%" }}
           link={notesPath}
         >
@@ -57,40 +58,47 @@ export default function NotesOverview(props: NotesOverviewProps) {
               </tr>
             </thead>
             <tbody>
-              {patientNotes.slice(0, 5).map(note => (
-                <tr key={note.uuid} className={styles.notesTableRow}>
-                  <td className={styles.noteDate}>
-                    {formatNotesDate(note?.encounterDatetime)}
-                  </td>
-                  <td className={styles.noteInfo}>
-                    <span>{note?.encounterType?.name}</span>
-                    <div>{note?.location?.name}</div>
-                  </td>
-                  <td className={styles.noteAuthor}>
-                    {!isEmpty(note.encounterProviders)
-                      ? note?.encounterProviders[0]?.provider?.person?.display
-                      : "\u2014"}
-                  </td>
-                  <td>
-                    <Link to={`${notesPath}/${note.uuid}`}>
-                      <svg
-                        className="omrs-icon"
-                        fill="var(--omrs-color-ink-low-contrast)"
-                      >
-                        <use xlinkHref="#omrs-icon-chevron-right" />
-                      </svg>
-                    </Link>
-                  </td>
-                </tr>
-              ))}
+              {patientNotes
+                ?.filter(note => !!note)
+                .slice(0, 5)
+                .map(note => (
+                  <tr key={note.uuid} className={styles.notesTableRow}>
+                    <td className={styles.noteDate}>
+                      {formatNotesDate(note.encounterDatetime)}
+                    </td>
+                    <td className={styles.noteInfo}>
+                      <span>{note.encounterType?.name}</span>
+                      <div>{note.location?.name}</div>
+                    </td>
+                    <td className={styles.noteAuthor}>
+                      {note.encounterProviders.length
+                        ? note.encounterProviders[0].provider?.person?.display
+                        : "\u2014"}
+                    </td>
+                    <td>
+                      <Link to={`${notesPath}/${note.uuid}`}>
+                        <svg
+                          className="omrs-icon"
+                          fill="var(--omrs-color-ink-low-contrast)"
+                        >
+                          <use xlinkHref="#omrs-icon-chevron-right" />
+                        </svg>
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
             </tbody>
           </table>
           <SummaryCardFooter linkTo={notesPath} />
         </SummaryCard>
       ) : (
         <EmptyState
-          name="Notes"
-          displayText="This patient has no notes recorded in the system."
+          name={t("Notes")}
+          showComponent={() =>
+            openWorkspaceTab(VisitNotes, `${t("Visit Notes")}`)
+          }
+          addComponent={VisitNotes}
+          displayText={t("notes")}
         />
       )}
     </>

--- a/src/widgets/programs/programs-overview.component.tsx
+++ b/src/widgets/programs/programs-overview.component.tsx
@@ -42,17 +42,14 @@ export default function ProgramsOverview(props: ProgramsOverviewProps) {
 
   return (
     <>
-      {patientPrograms && patientPrograms.length > 0 ? (
+      {patientPrograms?.length > 0 ? (
         <SummaryCard
-          name={t("Care Programs", "Care Programs")}
+          name={t("Care Programs")}
           link={programsPath}
           styles={{ margin: "1.25rem, 1.5rem" }}
           addComponent={ProgramsForm}
           showComponent={() =>
-            openWorkspaceTab(
-              ProgramsForm,
-              `${t("Programs Form", "Programs Form")}`
-            )
+            openWorkspaceTab(ProgramsForm, `${t("Programs Form")}`)
           }
         >
           <SummaryCardRow>
@@ -90,10 +87,12 @@ export default function ProgramsOverview(props: ProgramsOverviewProps) {
         </SummaryCard>
       ) : (
         <EmptyState
-          showComponent={() => openWorkspaceTab(ProgramsForm, "Programs Form")}
+          showComponent={() =>
+            openWorkspaceTab(ProgramsForm, `${t("Programs Form")}`)
+          }
           addComponent={ProgramsForm}
-          name="Care Programs"
-          displayText="This patient has no program enrollments recorded in the system."
+          name={t("Care Programs")}
+          displayText={t("program enrollments")}
         />
       )}
     </>

--- a/src/widgets/types.ts
+++ b/src/widgets/types.ts
@@ -115,5 +115,5 @@ export type PatientNotes = {
     changedBy?: any;
     dateChanged?: Date;
   };
-  encounterProviders: { provider: { person: { display: string } } };
+  encounterProviders: [{ provider: { person: { display: string } } }];
 };

--- a/src/widgets/vitals/vitals-overview.component.tsx
+++ b/src/widgets/vitals/vitals-overview.component.tsx
@@ -57,12 +57,14 @@ function VitalsOverview(props: VitalsOverviewProps) {
 
   return (
     <>
-      {currentVitals && currentVitals.length > 0 ? (
+      {currentVitals?.length > 0 ? (
         <SummaryCard
-          name={t("vitals", "Vitals")}
+          name={t("Vitals")}
           link={props.basePath}
           addComponent={VitalsForm}
-          showComponent={() => openWorkspaceTab(VitalsForm, "Vitals Form")}
+          showComponent={() =>
+            openWorkspaceTab(VitalsForm, `${t("Vitals Form")}`)
+          }
         >
           <table className={`omrs-type-body-regular ${styles.vitalsTable}`}>
             <thead>
@@ -126,10 +128,12 @@ function VitalsOverview(props: VitalsOverviewProps) {
         </SummaryCard>
       ) : (
         <EmptyState
-          showComponent={() => openWorkspaceTab(VitalsForm, "Vitals Form")}
+          showComponent={() =>
+            openWorkspaceTab(VitalsForm, `${t("Vitals Form")}`)
+          }
           addComponent={VitalsForm}
-          name="Vitals"
-          displayText="This patient has no vitals recorded in the system."
+          name={t("Vitals")}
+          displayText={t("vitals")}
         />
       )}
     </>


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-219

This is the beginning of efforts aimed at bringing full translation support to the patient chart widgets.

This PR adds translation strings for the EmptyState component and configures it to take in translated strings through the `displayText` prop.

<img width="1321" alt="Screenshot 2020-06-09 at 19 34 00" src="https://user-images.githubusercontent.com/8509731/84175153-3c2bd080-aa88-11ea-86f9-89faed031a71.png">