### PR TITLE
MF-125: Fix timezone issues when running tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5591,6 +5591,58 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "prettier": "prettier",
     "typescript": "tsc",
     "prepublishOnly": "npm run build",
-    "test": "jest --config jest.config.json --verbose false",
-    "coverage": "npm test -- --coverage"
+    "test": "cross-env TZ=utc jest --config jest.config.json --verbose false",
+    "coverage": "cross-env TZ=utc npm test -- --coverage"
   },
   "repository": {
     "type": "git",
@@ -54,6 +54,7 @@
     "browserslist-config-openmrs": "^1.0.1",
     "clean-webpack-plugin": "^3.0.0",
     "concurrently": "^5.1.0",
+    "cross-env": "^7.0.2",
     "css-loader": "^3.5.2",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-125

Tests that assert whether mocked times match what gets rendered in the UI sometimes fail either locally or in the CI environment because of UTC offset mismatches. Since the server uses UTC+0, it would make sense to make our local test environment use the same timezone offset to avoid such issues.

For example, the snippet attached shows an assertion that is passing locally but failing in Travis. My local environment is UTC+3 whereas Travis is UTC+0. The test failure messages show that the times are set to UTC+0 in the rendered content.

<img width="525" alt="Screenshot 2020-06-10 at 21 26 02" src="https://user-images.githubusercontent.com/8509731/84307906-51772c80-ab66-11ea-8159-53dccbedbb4e.png">

<img width="1250" alt="Screenshot 2020-06-10 at 21 51 26" src="https://user-images.githubusercontent.com/8509731/84307941-5d62ee80-ab66-11ea-9514-9954afc0d0b0.png">

<img width="735" alt="Screenshot 2020-06-10 at 22 06 24" src="https://user-images.githubusercontent.com/8509731/84308110-a4e97a80-ab66-11ea-89c3-35b57e254960.png">

I could write a test to assert that the UTC offset is being set to 0 but I'm not sure where the right place to put that would be:

`expect(new Date().getTimezoneOffset()).toBe(0)`