### PR TITLE
Specify compatible patient-chart verion in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ Patient chart widgets microfrontend for the OpenMRS SPA
 More info on the [wiki][]
 
 [wiki]: https://wiki.openmrs.org/display/projects/openmrs-esm-patient-chart
+
+##### Combatibility with Patient Chart:
+
+| Patient Chart Widget Version | Patient Chart Version |
+| ---------------------------- | --------------------- |
+| 1.0.3                        | 0.0.1                 |

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ More info on the [wiki][]
 
 | Patient Chart Widget Version | Patient Chart Version |
 | ---------------------------- | --------------------- |
-| 1.0.3                        | 0.0.1                 |
+| 1.0.3                        | 0.1.0                 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-chart-widgets",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -91,9 +91,6 @@
     "react-router-dom": "^5.1.2",
     "rxjs": "^6.5.5"
   },
-  "peerDependencies": {
-    "@openmrs/esm-patient-chart-app": "0.0.1"
-  },
   "author": "",
   "license": "MPL-2.0",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-chart-widgets",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "Patient dashboard widgets microfrontend for the OpenMRS SPA",
   "main": "dist/openmrs-esm-patient-chart-widgets.js",
   "scripts": {
@@ -90,6 +90,9 @@
     "react-i18next": "^11.3.4",
     "react-router-dom": "^5.1.2",
     "rxjs": "^6.5.5"
+  },
+  "peerDependencies": {
+    "@openmrs/esm-patient-chart-app": "0.0.1"
   },
   "author": "",
   "license": "MPL-2.0",


### PR DESCRIPTION
As part of this PR following things have been done:
- [x] Add Patient chart compatibility table in readme which can have a history of all the versions of patient-chart widgets and their compatible patient-chart version.
- [x] ~~Add Patient chart current version as [peer dependency](https://nodejs.org/es/blog/npm/peer-dependencies/).~~