### PR TITLE
MF-219: Add height and weight widget translations

### DIFF
--- a/__mocks__/dimensions.mock.ts
+++ b/__mocks__/dimensions.mock.ts
@@ -130,7 +130,7 @@ export const mockDimensionsResponse = [
     id: "51cd7805-1171-491c-823f-c67afce84614",
     weight: 80,
     height: 165,
-    date: "06-Apr 03:09 PM",
+    date: "13-Apr 03:09 PM",
     bmi: "29.4",
     obsData: {
       weight: {
@@ -256,7 +256,7 @@ export const mockDimensionsResponse = [
   {
     id: "49fbba96-08eb-4b22-83f8-84753a15e70d",
     height: 186,
-    date: "06-Apr 11:47 AM",
+    date: "09-Apr 11:47 AM",
     bmi: null,
     obsData: {
       height: {

--- a/src/widgets/heightandweight/heightandweight-overview.component.tsx
+++ b/src/widgets/heightandweight/heightandweight-overview.component.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { useTranslation, Trans } from "react-i18next";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import { ConfigObject } from "../../config-schema";
 import SummaryCardFooter from "../../ui-components/cards/summary-card-footer.component";
@@ -13,17 +14,11 @@ import VitalsForm from "../vitals/vitals-form.component";
 import withConfig from "../../with-config";
 import styles from "./heightandweight-overview.css";
 import { getDimensions } from "./heightandweight.resource";
-import { useTranslation } from "react-i18next";
 
 function HeightAndWeightOverview(props: HeightAndWeightOverviewProps) {
   const [dimensions, setDimensions] = React.useState([]);
   const [showMore, setShowMore] = React.useState(false);
-  const [
-    isLoadingPatient,
-    patient,
-    patientUuid,
-    patientErr
-  ] = useCurrentPatient();
+  const [, , patientUuid] = useCurrentPatient();
   const chartBasePath = useChartBasePath();
   const heightweightPath = chartBasePath + "/" + props.basePath;
   const { t } = useTranslation();
@@ -66,9 +61,15 @@ function HeightAndWeightOverview(props: HeightAndWeightOverviewProps) {
                       className={`${styles.tableHeader} ${styles.tableDates}`}
                       style={{ textAlign: "start" }}
                     ></th>
-                    <th className={styles.tableHeader}>Weight</th>
-                    <th className={styles.tableHeader}>Height</th>
-                    <th className={styles.tableHeader}>BMI</th>
+                    <th className={styles.tableHeader}>
+                      <Trans i18nKey="weight">Weight</Trans>
+                    </th>
+                    <th className={styles.tableHeader}>
+                      <Trans i18nKey="height">Height</Trans>
+                    </th>
+                    <th className={styles.tableHeader}>
+                      <Trans i18nKey="bmi">BMI</Trans>
+                    </th>
                     <th></th>
                   </tr>
                 </thead>

--- a/src/widgets/heightandweight/heightandweight-record.component.tsx
+++ b/src/widgets/heightandweight/heightandweight-record.component.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useRouteMatch } from "react-router-dom";
-import { useTranslation } from "react-i18next";
+import { useTranslation, Trans } from "react-i18next";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import { ConfigObject } from "../../config-schema";
@@ -19,15 +19,10 @@ import { getDimensions } from "./heightandweight.resource";
 import styles from "./heightandweight-record.css";
 
 function HeightAndWeightRecord(props: HeightAndWeightRecordProps) {
-  const { t } = useTranslation();
   const [dimensions, setDimensions] = useState<any>({});
-  const [
-    isLoadingPatient,
-    patient,
-    patientUuid,
-    patientErr
-  ] = useCurrentPatient();
+  const [isLoadingPatient, , patientUuid] = useCurrentPatient();
   const match = useRouteMatch();
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (!isLoadingPatient && patientUuid && match.params) {
@@ -58,9 +53,9 @@ function HeightAndWeightRecord(props: HeightAndWeightRecordProps) {
       {!!(dimensions && Object.entries(dimensions).length) && (
         <div className={styles.dimensionsContainer}>
           <SummaryCard
-            name="Height & Weight"
+            name={t("Height & Weight", "Height & Weight")}
             showComponent={() =>
-              openWorkspaceTab(VitalsForm, "Edit Vitals Form", {
+              openWorkspaceTab(VitalsForm, "Edit vitals", {
                 vitalUuid: match.params["heightWeightUuid"]
               })
             }
@@ -68,59 +63,89 @@ function HeightAndWeightRecord(props: HeightAndWeightRecordProps) {
             styles={{ width: "100%" }}
           >
             <div className={styles.dimensionsCard}>
-              <table className={styles.summaryTable}>
-                <tbody>
-                  <tr>
-                    <td>Measured at </td>
-                    <td>
-                      {[
-                        customDateFormat(
-                          dimensions?.obsData?.weight?.effectiveDatetime,
-                          "DD-MMM-YYYY"
-                        ),
-                        customDateFormat(
-                          dimensions?.obsData?.weight?.effectiveDatetime,
-                          "HH:mm A"
-                        )
-                      ].join(" ")}
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Weight</td>
-                    <td>
-                      {dimensions.weight} <span>kg</span>
-                    </td>
-                    <td>
-                      {convertToPounds(dimensions.weight)} <span>lbs</span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Height</td>
-                    <td>
-                      {dimensions.height} <span>cm</span>
-                    </td>
-                    <td>
-                      {convertToFeet(dimensions.height)} <span>feet</span>{" "}
-                      {convertoToInches(dimensions.height)} <span>inches</span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>BMI</td>
-                    <td>
-                      {dimensions.bmi} <span>Kg/m2</span>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+              {Object.entries(dimensions).length && (
+                <table className={styles.summaryTable}>
+                  <tbody>
+                    <tr>
+                      <td>
+                        <Trans i18nKey="measuredAt">Measured at</Trans>
+                      </td>
+                      <td>
+                        {[
+                          customDateFormat(
+                            dimensions?.obsData?.weight?.effectiveDatetime,
+                            "DD-MMM-YYYY"
+                          ),
+                          customDateFormat(
+                            dimensions?.obsData?.weight?.effectiveDatetime,
+                            "HH:mm A"
+                          )
+                        ].join(" ")}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <Trans i18nKey="weight">Weight</Trans>
+                      </td>
+                      <td>
+                        {dimensions.weight}{" "}
+                        <span>
+                          <Trans i18nKey="kg">kg</Trans>
+                        </span>
+                      </td>
+                      <td>
+                        {convertToPounds(dimensions.weight)} <span>lbs</span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <Trans i18nKey="height">Height</Trans>
+                      </td>
+                      <td>
+                        {dimensions.height} <span>cm</span>
+                      </td>
+                      <td>
+                        {convertToFeet(dimensions.height)}{" "}
+                        <span>
+                          <Trans i18nKey="feet">feet</Trans>
+                        </span>{" "}
+                        {convertoToInches(dimensions.height)}{" "}
+                        <span>
+                          <Trans i18nKey="inches">inches</Trans>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <Trans i18nKey="bmi">BMI</Trans>
+                      </td>
+                      <td>
+                        {dimensions.bmi}{" "}
+                        <span>
+                          kg/m<sup>2</sup>
+                        </span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              )}
             </div>
           </SummaryCard>
           <RecordDetails>
             <table className={styles.heightAndWeightDetailsTable}>
               <thead>
                 <tr>
-                  <td>Last updated</td>
-                  <td>Last updated by</td>
-                  <td>Last updated location</td>
+                  <td>
+                    <Trans i18nKey="lastUpdated">Last updated</Trans>
+                  </td>
+                  <td>
+                    <Trans i18nKey="lastUpdatedBy">Last updated by</Trans>
+                  </td>
+                  <td>
+                    <Trans i18nKey="lastUpdatedLocation">
+                      Last updated location
+                    </Trans>
+                  </td>
                 </tr>
               </thead>
               <tbody>

--- a/src/widgets/heightandweight/heightandweight-summary.component.tsx
+++ b/src/widgets/heightandweight/heightandweight-summary.component.tsx
@@ -1,27 +1,23 @@
-import React from "react";
-import styles from "./heightandweight-summary.css";
-import SummaryCard from "../../ui-components/cards/summary-card.component";
-import { getDimensions } from "./heightandweight.resource";
-import { useCurrentPatient } from "@openmrs/esm-api";
+import React, { useEffect, useState } from "react";
+import { useTranslation, Trans } from "react-i18next";
 import { Link, useRouteMatch } from "react-router-dom";
+import styles from "./heightandweight-summary.css";
+import { useCurrentPatient } from "@openmrs/esm-api";
+import EmptyState from "../../ui-components/empty-state/empty-state.component";
+import SummaryCard from "../../ui-components/cards/summary-card.component";
 import VitalsForm from "../vitals/vitals-form.component";
+import { getDimensions } from "./heightandweight.resource";
 import { openWorkspaceTab } from "../shared-utils";
-import withConfig from "../../with-config";
-import { useTranslation } from "react-i18next";
 import { ConfigObject } from "../../config-schema";
+import withConfig from "../../with-config";
 
 function HeightAndWeightSummary(props: HeightAndWeightSummaryProps) {
   const match = useRouteMatch();
   const { t } = useTranslation();
-  const [dimensions, setDimensions] = React.useState([]);
-  const [
-    isLoadingPatient,
-    patient,
-    patientUuid,
-    patientErr
-  ] = useCurrentPatient();
+  const [dimensions, setDimensions] = useState([]);
+  const [, , patientUuid] = useCurrentPatient();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (patientUuid) {
       const sub = getDimensions(
         props.config.concepts.weightUuid,
@@ -35,64 +31,83 @@ function HeightAndWeightSummary(props: HeightAndWeightSummaryProps) {
   }, [patientUuid, props.config]);
 
   return (
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "center",
-        paddingTop: "0.5rem"
-      }}
-    >
-      <SummaryCard
-        name={t("Height & Weight", "Height & Weight")}
-        styles={{ flex: 1, margin: ".5rem" }}
-        addComponent={VitalsForm}
-        showComponent={() => openWorkspaceTab(VitalsForm, "Vitals Form")}
-      >
-        <table className={styles.table}>
-          <thead>
-            <tr className={styles.tableRow}>
-              <th className={`${styles.tableHeader} ${styles.tableDates}`}></th>
-              <th className={styles.tableHeader}>Weight (kg)</th>
-              <th className={styles.tableHeader}>Height (cm)</th>
-              <th className={styles.tableHeader}>
-                BMI (kg/m<sup>2</sup>)
-              </th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            {dimensions.map((dimension, index) => (
-              <tr key={index} className={styles.tableRow}>
-                <td className={styles.tableData} style={{ textAlign: "start" }}>
-                  <span style={{ fontWeight: 500 }}>
-                    {dimension.date.split(" ")[0]}
-                  </span>{" "}
-                  {dimension.date.slice(
-                    dimension.date.indexOf(" ") + 1,
-                    dimension.date.length
-                  )}
-                </td>
-                <td className={styles.tableData}>
-                  {dimension.weight || "\u2014"}
-                </td>
-                <td className={styles.tableData}>
-                  {dimension.height || "\u2014"}
-                </td>
-                <td className={styles.tableData}>
-                  {dimension.bmi || "\u2014"}
-                </td>
-                <td style={{ textAlign: "end" }}>
-                  <Link to={`${match.path}/${dimension.id}`}>
-                    <svg className="omrs-icon" fill="rgba(0, 0, 0, 0.54)">
-                      <use xlinkHref="#omrs-icon-chevron-right" />
-                    </svg>
-                  </Link>
-                </td>
+    <div className="styles.dimensionsSummary">
+      {dimensions && dimensions.length ? (
+        <SummaryCard
+          name={t("Height & Weight")}
+          addComponent={VitalsForm}
+          showComponent={() =>
+            openWorkspaceTab(VitalsForm, `${t("Vitals Form")}`)
+          }
+        >
+          <table className={styles.table}>
+            <thead>
+              <tr className={styles.tableRow}>
+                <th
+                  className={`${styles.tableHeader} ${styles.tableDates}`}
+                ></th>
+                <th className={styles.tableHeader}>
+                  <Trans i18nKey="weight">
+                    Weight (<Trans i18nKey="kg">kg</Trans>)
+                  </Trans>
+                </th>
+                <th className={styles.tableHeader}>
+                  <Trans i18nKey="height">
+                    Height (<Trans i18nKey="cm">cm</Trans>)
+                  </Trans>
+                </th>
+                <th className={styles.tableHeader}>
+                  <Trans i18nKey="bmi">BMI</Trans> (kg/m<sup>2</sup>)
+                </th>
+                <th></th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </SummaryCard>
+            </thead>
+            <tbody>
+              {dimensions.map(dimension => (
+                <tr key={dimension.id} className={styles.tableRow}>
+                  <td
+                    className={styles.tableData}
+                    style={{ textAlign: "start" }}
+                  >
+                    <span style={{ fontWeight: 500 }}>
+                      {dimension.date.split(" ")[0]}
+                    </span>{" "}
+                    {dimension.date.slice(
+                      dimension.date.indexOf(" ") + 1,
+                      dimension.date.length
+                    )}
+                  </td>
+                  <td className={styles.tableData}>
+                    {dimension.weight || "\u2014"}
+                  </td>
+                  <td className={styles.tableData}>
+                    {dimension.height || "\u2014"}
+                  </td>
+                  <td className={styles.tableData}>
+                    {dimension.bmi || "\u2014"}
+                  </td>
+                  <td style={{ textAlign: "end" }}>
+                    <Link to={`${match.path}/${dimension.id}`}>
+                      <svg className="omrs-icon" fill="rgba(0, 0, 0, 0.54)">
+                        <use xlinkHref="#omrs-icon-chevron-right" />
+                      </svg>
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </SummaryCard>
+      ) : (
+        <EmptyState
+          name={t("Height & Weight")}
+          showComponent={() =>
+            openWorkspaceTab(VitalsForm, `${t("Vitals Form")}`)
+          }
+          addComponent={VitalsForm}
+          displayText={t("dimensions", "dimensions")}
+        />
+      )}
     </div>
   );
 }

--- a/src/widgets/heightandweight/heightandweight-summary.css
+++ b/src/widgets/heightandweight/heightandweight-summary.css
@@ -29,6 +29,15 @@
   width: 70%;
 }
 
+:global(.omrs-breakpoint-gt-phone) .dimensionsSummary {
+  display: flex;
+  justify-content: center;
+}
+
+:global(.omrs-breakpoint-lt-tablet) .dimensionsSummary {
+  padding: 0.25rem 0.5rem 0 0.5rem;
+}
+
 table.table .tableDates {
   text-align: start;
 }

--- a/src/widgets/vitals/vitals-form.component.tsx
+++ b/src/widgets/vitals/vitals-form.component.tsx
@@ -26,7 +26,7 @@ function VitalsForm(props: VitalsFormProps) {
   const [patientVitals, setPatientVitals] = useState<PatientVitals>(null);
   const formRef = useRef<HTMLFormElement>(null);
   const [, setEncounterProvider] = useState(null);
-  const [systolicBloodPressure, setSytolicBloodPressure] = useState(null);
+  const [systolicBloodPressure, setSystolicBloodPressure] = useState(null);
   const [diastolicBloodPressure, setDiastolicBloodPressure] = useState(null);
   const [pulse, setPulse] = useState(null);
   const [oxygenSaturation, setOxygenSaturation] = useState(null);
@@ -37,14 +37,14 @@ function VitalsForm(props: VitalsFormProps) {
     dayjs.utc(new Date()).format("YYYY-MM-DD")
   );
   const [timeRecorded, setTimeRecorded] = useState(
-    dayjs.utc(new Date()).format("HH:mm")
+    dayjs(new Date()).format("HH:mm")
   );
   const [isLoadingPatient, , patientUuid] = useCurrentPatient();
   const [, setCurrentSession] = useState();
   const [location, setLocation] = useState<string>(null);
   const [formChanged, setFormChanged] = useState(false);
-  const { t } = useTranslation();
   const history = useHistory();
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (props.match.params["vitalUuid"]) {
@@ -61,7 +61,7 @@ function VitalsForm(props: VitalsFormProps) {
           );
           setPatientVitals(vitalSigns);
           setTemperature(vitalSigns?.temperature);
-          setSytolicBloodPressure(vitalSigns?.systolic);
+          setSystolicBloodPressure(vitalSigns?.systolic);
           setDiastolicBloodPressure(vitalSigns?.diastolic);
           setTimeRecorded(vitalSigns?.date.toString());
           setOxygenSaturation(vitalSigns?.oxygenSaturation);
@@ -82,19 +82,19 @@ function VitalsForm(props: VitalsFormProps) {
   ]);
 
   useEffect(() => {
-    if (patientUuid && !isLoadingPatient) {
-      const abortController = new AbortController();
-      getSession(abortController)
-        .then(response => {
-          const { data } = response;
-          setEncounterProvider(data?.currentProvider?.uuid);
-          setCurrentSession(data);
-          setLocation(data?.sessionLocation?.uuid);
-        })
-        .catch(createErrorHandler());
-      return () => abortController.abort();
-    }
-  }, [patientUuid, isLoadingPatient]);
+    const abortController = new AbortController();
+
+    getSession(abortController)
+      .then(response => {
+        const { data } = response;
+        setEncounterProvider(data?.currentProvider?.uuid);
+        setCurrentSession(data);
+        setLocation(data?.sessionLocation?.uuid);
+      })
+      .catch(createErrorHandler());
+
+    return () => abortController.abort();
+  }, []);
 
   useEffect(() => {
     if (!viewEditForm) {
@@ -215,11 +215,11 @@ function VitalsForm(props: VitalsFormProps) {
       <form
         className={styles.vitalsForm}
         onSubmit={handleCreateFormSubmit}
-        ref={formRef}
         onChange={() => {
           setFormChanged(true);
           return props.entryStarted();
         }}
+        ref={formRef}
       >
         <SummaryCard
           name={t("Add vitals, height and weight")}
@@ -266,7 +266,7 @@ function VitalsForm(props: VitalsFormProps) {
                       name="systolicBloodPressure"
                       className={styles.vitalInputControl}
                       onChange={evt =>
-                        setSytolicBloodPressure(evt.target.value)
+                        setSystolicBloodPressure(evt.target.value)
                       }
                       autoComplete="off"
                     />
@@ -583,7 +583,7 @@ function VitalsForm(props: VitalsFormProps) {
                           className={styles.vitalInputControl}
                           value={systolicBloodPressure}
                           onChange={evt =>
-                            setSytolicBloodPressure(evt.target.value)
+                            setSystolicBloodPressure(evt.target.value)
                           }
                         />
                         <span>mmHg</span>

--- a/src/widgets/vitals/vitals-form.test.tsx
+++ b/src/widgets/vitals/vitals-form.test.tsx
@@ -128,7 +128,7 @@ describe("<VitalsForm />", () => {
     expect(screen.getByDisplayValue(todaysDate)).toBeInTheDocument();
 
     // Time recorded is prefilled with the current time
-    const currentTime = dayjs.utc(new Date()).format("HH:mm");
+    const currentTime = dayjs(new Date()).format("HH:mm");
     expect(screen.getByDisplayValue(currentTime)).toBeInTheDocument();
 
     const createTimestamp = new Date(`${todaysDate} ${currentTime}`);


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-219

This PR:

- Adds translations strings for the components that make up the height and weight widget.
- Bumps test statement coverage up to 93%.

Progress on i18n can be followed here: https://issues.openmrs.org/browse/MF-219