### PR TITLE
MF-219: Add patient banner translations

### DIFF
--- a/src/widgets/banner/patient-banner.component.tsx
+++ b/src/widgets/banner/patient-banner.component.tsx
@@ -4,6 +4,7 @@ import { age } from "../profile/age-helpers";
 import dayjs from "dayjs";
 import ProfileSection from "../profile/profile-section.component";
 import { useCurrentPatient } from "@openmrs/esm-api";
+import { Trans } from "react-i18next";
 
 export default function PatientBanner(props: PatientBannerProps) {
   const [showingDemographics, setShowDemographics] = React.useState(false);
@@ -34,7 +35,7 @@ export default function PatientBanner(props: PatientBannerProps) {
             </div>
             <div className={`${styles.otherDemographics}`}>
               <span className={`${styles.desktopLabel} omrs-type-body-small`}>
-                Born
+                <Trans i18nKey="born">Born</Trans>
               </span>
               <span
                 className={`${styles.demographic} ${styles.hideDemographics} omrs-type-body-regular`}
@@ -44,7 +45,7 @@ export default function PatientBanner(props: PatientBannerProps) {
             </div>
             <div className={`${styles.otherDemographics}`}>
               <span className={`${styles.desktopLabel} omrs-type-body-small`}>
-                Gender
+                <Trans i18nKey="gender">Gender</Trans>
               </span>
               <span className={`${styles.demographic} omrs-type-body-regular`}>
                 {patient.gender}
@@ -52,7 +53,7 @@ export default function PatientBanner(props: PatientBannerProps) {
             </div>
             <div className={`${styles.otherDemographics}`}>
               <span className={`${styles.desktopLabel} omrs-type-body-small`}>
-                Preferred ID
+                <Trans i18nKey="preferredId">Preferred ID</Trans>
               </span>
               <span className={`${styles.demographic} omrs-type-body-regular`}>
                 {getPreferredIdentifier()}
@@ -64,7 +65,11 @@ export default function PatientBanner(props: PatientBannerProps) {
               className={`${styles.moreBtn} omrs-unstyled`}
               onClick={toggleDemographics}
             >
-              {showingDemographics ? "Close" : "Open"}
+              {showingDemographics ? (
+                <Trans i18nKey="close">Close</Trans>
+              ) : (
+                <Trans i18nKey="open">Open</Trans>
+              )}
             </button>
             <svg
               className={`omrs-icon`}


### PR DESCRIPTION
This PR adds translations strings for the patient banner as part of the effort to get full i18n support across the patient chart widgets. Progress on this effort can be followed here: https://issues.openmrs.org/browse/MF-219

<img width="1439" alt="Screenshot 2020-06-16 at 09 57 59" src="https://user-images.githubusercontent.com/8509731/84741530-e7241900-afb7-11ea-85f7-d855dae7d6ae.png">