### PR TITLE
MF-219: Add translations for reusable UI components

### DIFF
--- a/src/ui-components/cards/horizontal-label-value.component.tsx
+++ b/src/ui-components/cards/horizontal-label-value.component.tsx
@@ -1,16 +1,14 @@
 import React from "react";
 import styles from "./horizontal-label-value.css";
-import { useTranslation } from "react-i18next";
 
 export default function HorizontalLabelValue(props: HorizontalLabelValueProps) {
-  const { t } = useTranslation();
   return (
     <div className={styles.root}>
       <label
         className={props.labelClassName || "omrs-type-body-regular"}
         style={props.labelStyles}
       >
-        {t(props.label)}
+        {props.label}
         {props.specialKey && <sup>{"\u002A"}</sup>}
       </label>
       <div

--- a/src/ui-components/cards/horizontal-label-value.component.tsx
+++ b/src/ui-components/cards/horizontal-label-value.component.tsx
@@ -1,14 +1,16 @@
 import React from "react";
 import styles from "./horizontal-label-value.css";
+import { useTranslation } from "react-i18next";
 
 export default function HorizontalLabelValue(props: HorizontalLabelValueProps) {
+  const { t } = useTranslation();
   return (
     <div className={styles.root}>
       <label
         className={props.labelClassName || "omrs-type-body-regular"}
         style={props.labelStyles}
       >
-        {props.label}
+        {t(props.label)}
         {props.specialKey && <sup>{"\u002A"}</sup>}
       </label>
       <div

--- a/src/ui-components/cards/record-details-card.component.tsx
+++ b/src/ui-components/cards/record-details-card.component.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import SummaryCard from "../cards/summary-card.component";
 import styles from "./record-details-card.css";
+import { useTranslation } from "react-i18next";
 
 export default function RecordDetails(props: DetailsProps) {
+  const { t } = useTranslation();
+
   return (
     <SummaryCard
-      name="Details"
+      name={t("Details")}
       styles={{
         width: "100%",
         backgroundColor: "var(--omrs-color-bg-medium-contrast)"

--- a/src/ui-components/cards/summary-card-footer.component.tsx
+++ b/src/ui-components/cards/summary-card-footer.component.tsx
@@ -1,17 +1,20 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import styles from "./summary-card-footer.css";
+import { Trans } from "react-i18next";
 
 export default function SummaryCardFooter(props: SummaryCardFooterProps) {
   if (!props.linkTo) {
     return (
       <div className={styles.footer}>
-        <p className="omrs-bold">See all</p>
+        <p className="omrs-bold">
+          <Trans i18nKey="seeAll">See all</Trans>
+        </p>
       </div>
     );
   }
   return (
-    <div className={`${styles.footer}`}>
+    <div className={styles.footer}>
       <svg className="omrs-icon" fill="var(--omrs-color-ink-medium-contrast)">
         <use xlinkHref="#omrs-icon-chevron-right" />
       </svg>
@@ -20,7 +23,9 @@ export default function SummaryCardFooter(props: SummaryCardFooterProps) {
         className={`omrs-unstyled`}
         style={{ border: "none" }}
       >
-        <p className="omrs-bold">See all</p>
+        <p className="omrs-bold">
+          <Trans i18nKey="seeAll">See all</Trans>
+        </p>
       </Link>
     </div>
   );

--- a/src/ui-components/cards/summary-card.component.tsx
+++ b/src/ui-components/cards/summary-card.component.tsx
@@ -1,10 +1,9 @@
-import React, { ReactChildren } from "react";
+import React from "react";
 import styles from "./summary-card.css";
 import { Link } from "react-router-dom";
-import { Trans, useTranslation } from "react-i18next";
+import { Trans } from "react-i18next";
 
 export default function SummaryCard(props: SummaryCardProps) {
-  const { t } = useTranslation();
   return (
     <div style={props.styles} className={`omrs-card ${styles.card}`}>
       <div className={styles.header}>
@@ -25,7 +24,7 @@ export default function SummaryCard(props: SummaryCardProps) {
                 props.showComponent(props.addComponent, props.name)
               }
             >
-              Add
+              <Trans i18nKey="add">Add</Trans>
             </button>
           </div>
         )}
@@ -37,7 +36,7 @@ export default function SummaryCard(props: SummaryCardProps) {
                 props.showComponent(props.editComponent, props.name)
               }
             >
-              Edit
+              <Trans i18nKey="edit">Edit</Trans>
             </button>
           </div>
         )}
@@ -45,7 +44,7 @@ export default function SummaryCard(props: SummaryCardProps) {
           <div className={styles.headerEdit}>
             <button className={`omrs-unstyled ${styles.editBtn}`}>
               <Link className="omrs-unstyled" to={props.editBtnUrl}>
-                Edit
+                <Trans i18nKey="edit">Edit</Trans>
               </Link>
             </button>
           </div>

--- a/src/ui-components/sidebar/sidebar.component.tsx
+++ b/src/ui-components/sidebar/sidebar.component.tsx
@@ -4,23 +4,25 @@ import AllergyForm from "../../widgets/allergies/allergy-form.component";
 import Parcel from "single-spa-react/parcel";
 import VitalsForm from "../../widgets/vitals/vitals-form.component";
 import { openWorkspaceTab } from "../../widgets/shared-utils";
+import { useTranslation } from "react-i18next";
 
 export default function Sidebar(props: any) {
+  const { t } = useTranslation();
   const formentryParcel = () => (
     <Parcel config={System.import("@ampath/esm-angular-form-entry")} />
   );
   const sidebarItems = [
     {
       name: "A",
-      onclick: () => openWorkspaceTab(AllergyForm, "Allergy Form")
+      onclick: () => openWorkspaceTab(AllergyForm, `${t("Allergies Form")}`)
     },
     {
       name: "V",
-      onclick: () => openWorkspaceTab(VitalsForm, "Vitals")
+      onclick: () => openWorkspaceTab(VitalsForm, `${t("Vitals Form")}`)
     },
     {
       name: "F",
-      onclick: () => openWorkspaceTab(formentryParcel, "Forms")
+      onclick: () => openWorkspaceTab(formentryParcel, `${t("Forms")}`)
     }
   ];
   return (

--- a/src/widgets/conditions/conditions-overview.component.tsx
+++ b/src/widgets/conditions/conditions-overview.component.tsx
@@ -41,7 +41,7 @@ export default function ConditionsOverview(props: ConditionsOverviewProps) {
 
   return (
     <SummaryCard
-      name={t("conditions", "Conditions")}
+      name={t("Conditions", "Conditions")}
       styles={{ margin: "1.25rem, 1.5rem" }}
       link={conditionsPath}
       addComponent={ConditionsForm}
@@ -50,12 +50,12 @@ export default function ConditionsOverview(props: ConditionsOverviewProps) {
       <SummaryCardRow>
         <SummaryCardRowContent>
           <HorizontalLabelValue
-            label="Active Conditions"
+            label={t("Active Conditions", "Active Conditions")}
             labelStyles={{
               color: "var(--omrs-color-ink-medium-contrast)",
               fontFamily: "Work Sans"
             }}
-            value="Since"
+            value={t("Since", "Since")}
             valueStyles={{
               color: "var(--omrs-color-ink-medium-contrast)",
               fontFamily: "Work Sans"


### PR DESCRIPTION
This PR adds translations strings for the following reusable UI components:

- `HorizontalLabelValue`
- `RecordDetailsCard`
- `SummaryCard`
- `SummaryCardFooter`
- `Sidebar` 

Progress on i18n can be followed here: https://issues.openmrs.org/browse/MF-219