### PR TITLE
Fix withConfig so that vitals form works again

### DIFF
--- a/src/with-config.tsx
+++ b/src/with-config.tsx
@@ -11,7 +11,7 @@ export default function withConfig(Comp) {
 }
 
 function provideContext(Comp) {
-  return function ConfigContextProvider(props) {
+  return function WithContext(props) {
     return (
       <ModuleNameContext.Provider value="@openmrs/esm-patient-chart-widgets">
         <Comp {...props} />

--- a/src/with-config.tsx
+++ b/src/with-config.tsx
@@ -7,16 +7,23 @@ import { merge } from "lodash-es";
  * A HOC that injects configuration into widgets
  */
 export default function withConfig(Comp) {
+  return provideContext(injectConfig(Comp));
+}
+
+function provideContext(Comp) {
   return function ConfigContextProvider(props) {
-    const ConfigProvider = () => {
-      const moduleConfig = useConfig() as ConfigObject;
-      const config = merge(moduleConfig, props?.props?.config || {});
-      return <Comp config={config} {...props} />;
-    };
     return (
       <ModuleNameContext.Provider value="@openmrs/esm-patient-chart-widgets">
-        <ConfigProvider />
+        <Comp {...props} />
       </ModuleNameContext.Provider>
     );
+  };
+}
+
+function injectConfig(Comp) {
+  return function WithConfigProps(props) {
+    const moduleConfig = useConfig() as ConfigObject;
+    const config = merge(moduleConfig, props?.props?.config || {});
+    return <Comp config={config} {...props} />;
   };
 }


### PR DESCRIPTION
So I think what was happening is that before, the inner component was being re-created on each run of the outer component. Besides being inefficient, this caused the wrapped component state to get wiped out on each rerender.

I fixed it by making the code more normative -- I expressed the complex HOC as a composition of two very normal HOCs. Best practices FTW.

![Screenshot from 2020-07-02 11-32-14](https://user-images.githubusercontent.com/1031876/86396914-b4d11780-bc57-11ea-8a0d-4b8dbe0186ac.png)
