### PR TITLE
MF-219: Add allergies widget translations

### DIFF
--- a/src/widgets/allergies/allergies-detailed-summary.component.tsx
+++ b/src/widgets/allergies/allergies-detailed-summary.component.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Link, useRouteMatch } from "react-router-dom";
 import dayjs from "dayjs";
+import { useTranslation } from "react-i18next";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { openWorkspaceTab } from "../shared-utils";
@@ -19,6 +20,7 @@ export default function AllergiesDetailedSummary(
   const [patientAllergies, setPatientAllergies] = useState<Allergy[]>(null);
   const [isLoadingPatient, patient] = useCurrentPatient();
   const match = useRouteMatch();
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (!isLoadingPatient && patient) {
@@ -36,29 +38,33 @@ export default function AllergiesDetailedSummary(
     <>
       {patientAllergies?.length ? (
         <SummaryCard
-          name="Allergies"
+          name={t("Allergies", "Allergies")}
           styles={{ width: "100%" }}
           addComponent={AllergyForm}
           showComponent={() =>
-            openWorkspaceTab(AllergyForm, "Allergies Form", {
-              allergyUuid: null
-            })
+            openWorkspaceTab(
+              AllergyForm,
+              `${t("Allergies Form", "Allergies Form")}`,
+              {
+                allergyUuid: null
+              }
+            )
           }
         >
           <table className={`omrs-type-body-regular ${styles.allergyTable}`}>
             <thead>
               <tr>
-                <td>ALLERGEN</td>
+                <td>{t("Allergen", "Allergen")}</td>
                 <td>
                   <div className={styles.centerItems}>
-                    SEVERITY & REACTION
+                    {t("Severity & Reaction", "Severity & Reaction")}
                     <svg className="omrs-icon" fill="rgba(0, 0, 0, 0.54)">
                       <use xlinkHref="#omrs-icon-arrow-downward" />
                     </svg>
                   </div>
                 </td>
-                <td>SINCE</td>
-                <td>UPDATED</td>
+                <td>{t("Since", "Since")}</td>
+                <td>{t("Updated", "Updated")}</td>
               </tr>
             </thead>
             <tbody>
@@ -141,12 +147,16 @@ export default function AllergiesDetailedSummary(
         <EmptyState
           name="Allergies"
           showComponent={() =>
-            openWorkspaceTab(AllergyForm, "Allergies Form", {
-              allergyUuid: null
-            })
+            openWorkspaceTab(
+              AllergyForm,
+              `${t("Allergies Form", "Allergies Form")}`,
+              {
+                allergyUuid: null
+              }
+            )
           }
           addComponent={AllergyForm}
-          displayText="allergy intolerances"
+          displayText={t("allergy intolerances", "allergy intolerances")}
         />
       )}
     </>

--- a/src/widgets/allergies/allergies-detailed-summary.css
+++ b/src/widgets/allergies/allergies-detailed-summary.css
@@ -21,8 +21,9 @@
   border-bottom: 0.063rem solid var(--omrs-color-bg-low-contrast);
 }
 
-.allergyTable thead td {
+.allergyTable thead tr td {
   padding: 1rem 0.25rem 1rem 1rem;
+  text-transform: uppercase;
 }
 
 :global(.omrs-breakpoint-lt-tablet) .allergyTable thead td {

--- a/src/widgets/allergies/allergies-detailed-summary.test.tsx
+++ b/src/widgets/allergies/allergies-detailed-summary.test.tsx
@@ -47,10 +47,10 @@ describe("AllergiesDetailedSummary />", () => {
 
     await screen.findByText("Allergies");
     expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
-    expect(screen.getByText("ALLERGEN")).toBeInTheDocument();
-    expect(screen.getByText("SEVERITY & REACTION")).toBeInTheDocument();
-    expect(screen.getByText("SINCE")).toBeInTheDocument();
-    expect(screen.getByText("UPDATED")).toBeInTheDocument();
+    expect(screen.getByText("Allergen")).toBeInTheDocument();
+    expect(screen.getByText("Severity & Reaction")).toBeInTheDocument();
+    expect(screen.getByText("Since")).toBeInTheDocument();
+    expect(screen.getByText("Updated")).toBeInTheDocument();
     expect(screen.getByText("Cephalosporins")).toBeInTheDocument();
     expect(screen.getByText("Angioedema")).toBeInTheDocument();
     expect(screen.getByText("happened today")).toBeInTheDocument();

--- a/src/widgets/allergies/allergies-overview.component.tsx
+++ b/src/widgets/allergies/allergies-overview.component.tsx
@@ -61,14 +61,18 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
     <>
       {initialAllergiesBatch?.length > 0 ? (
         <SummaryCard
-          name={t("Allergies")}
+          name={t("Allergies", "Allergies")}
           styles={{ margin: "1.25rem, 1.5rem" }}
           link={`/patient/${patientUuid}/chart/allergies`}
           addComponent={AllergyForm}
           showComponent={() => {
-            openWorkspaceTab(AllergyForm, "Allergies Form", {
-              allergyUuid: null
-            });
+            openWorkspaceTab(
+              AllergyForm,
+              `${t("Allergies Form", "Allergies Form")}`,
+              {
+                allergyUuid: null
+              }
+            );
           }}
         >
           {initialAllergiesBatch.map(allergy => {
@@ -110,10 +114,15 @@ export default function AllergiesOverview(props: AllergiesOverviewProps) {
         </SummaryCard>
       ) : (
         <EmptyState
-          showComponent={() => openWorkspaceTab(AllergyForm, "Allergies Form")}
+          showComponent={() =>
+            openWorkspaceTab(
+              AllergyForm,
+              `${t("Allergies Form", "Allergies Form")}`
+            )
+          }
           addComponent={AllergyForm}
-          name={t("Allergies")}
-          displayText={t("allergy intolerances")}
+          name={t("Allergies", "Allergies")}
+          displayText={t("allergy intolerances", "allergy intolerances")}
         />
       )}
     </>

--- a/src/widgets/allergies/allergy-form.component.tsx
+++ b/src/widgets/allergies/allergy-form.component.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef, SyntheticEvent } from "react";
 import dayjs from "dayjs";
 import { capitalize } from "lodash-es";
 import { useHistory, match } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import styles from "./allergy-form.css";
 import {
@@ -47,6 +48,7 @@ export default function AllergyForm(props: AllergyFormProps) {
   const [isLoadingPatient, , patientUuid] = useCurrentPatient();
   const [formChanged, setFormChanged] = useState(false);
   const history = useHistory();
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (props.match.params["allergyUuid"]) {
@@ -224,11 +226,11 @@ export default function AllergyForm(props: AllergyFormProps) {
 
   const getAllergyType = (allergyConcept: string): string => {
     switch (allergyConcept) {
-      case AllergyConcepts.DRUG_ALLERGEN:
+      case AllergyConcept.DRUG_ALLERGEN:
         return "DRUG";
-      case AllergyConcepts.FOOD_ALLERGEN:
+      case AllergyConcept.FOOD_ALLERGEN:
         return "FOOD";
-      case AllergyConcepts.ENVIRONMENTAL_ALLERGEN:
+      case AllergyConcept.ENVIRONMENTAL_ALLERGEN:
         return "ENVIRONMENT";
       default:
         "NO ALLERGEN";
@@ -264,7 +266,7 @@ export default function AllergyForm(props: AllergyFormProps) {
   function createAllergy() {
     return (
       <SummaryCard
-        name="Add New Allergy"
+        name={t("Record a new allergy", "Record a new allergy")}
         styles={{
           width: "100%",
           background: "var(--omrs-color-bg-medium-contrast)"
@@ -279,44 +281,44 @@ export default function AllergyForm(props: AllergyFormProps) {
           }}
         >
           <h4 className={`${styles.allergyHeader} omrs-bold`}>
-            Category of reaction
+            {t("Category of reaction", "Category of reaction")}
           </h4>
           <div className={`${styles.container}`}>
             <div className="omrs-radio-button">
               <label>
                 <input
-                  id={AllergyConcepts.DRUG_ALLERGEN}
+                  id={AllergyConcept.DRUG_ALLERGEN}
                   type="radio"
                   name="allergenType"
-                  value={AllergyConcepts.DRUG_ALLERGEN}
+                  value={AllergyConcept.DRUG_ALLERGEN}
                   onChange={handleAllergenChange}
                   required
                 />
-                <span>Drug</span>
+                <span>{t("Drug", "Drug")}</span>
               </label>
             </div>
             <div className="omrs-radio-button">
               <label>
                 <input
-                  id={AllergyConcepts.FOOD_ALLERGEN}
+                  id={AllergyConcept.FOOD_ALLERGEN}
                   type="radio"
                   name="allergenType"
-                  value={AllergyConcepts.FOOD_ALLERGEN}
+                  value={AllergyConcept.FOOD_ALLERGEN}
                   onChange={handleAllergenChange}
                 />
-                <span>Food</span>
+                <span>{t("Food", "Food")}</span>
               </label>
             </div>
             <div className="omrs-radio-button">
               <label>
                 <input
-                  id={AllergyConcepts.ENVIRONMENTAL_ALLERGEN}
+                  id={AllergyConcept.ENVIRONMENTAL_ALLERGEN}
                   type="radio"
                   name="allergenType"
-                  value={AllergyConcepts.ENVIRONMENTAL_ALLERGEN}
+                  value={AllergyConcept.ENVIRONMENTAL_ALLERGEN}
                   onChange={handleAllergenChange}
                 />
-                <span>Environmental</span>
+                <span>{t("Environmental", "Environmental")}</span>
               </label>
             </div>
             <div className="omrs-radio-button">
@@ -328,7 +330,12 @@ export default function AllergyForm(props: AllergyFormProps) {
                   value="noAllergy"
                   onChange={handleAllergenChange}
                 />
-                <span>Patient has no known allergies</span>
+                <span>
+                  {t(
+                    "Patient has no known allergies",
+                    "Patient has no known allergies"
+                  )}
+                </span>
               </label>
             </div>
           </div>
@@ -338,7 +345,7 @@ export default function AllergyForm(props: AllergyFormProps) {
                 {capitalize(
                   getAllergyType(selectedAllergyCategory)?.toLowerCase()
                 )}{" "}
-                allergen
+                {t("allergen", "allergen")}
               </h4>
               <div className={styles.container}>
                 {allergensArray.map((allergen, index) => (
@@ -362,9 +369,11 @@ export default function AllergyForm(props: AllergyFormProps) {
           )}
           {allergensArray && allergicReactions && (
             <div>
-              <h4 className={`${styles.allergyHeader} omrs-bold`}>Reactions</h4>
+              <h4 className={`${styles.allergyHeader} omrs-bold`}>
+                {t("Reactions", "Reactions")}
+              </h4>
               <h4 className={`${styles.allergyHeader} omrs-type-body-regular`}>
-                Select all that apply
+                {t("Select all that apply", "Select all that apply")}
               </h4>
               <div className={styles.container}>
                 {allergicReactions.map((reaction, index) => (
@@ -387,7 +396,7 @@ export default function AllergyForm(props: AllergyFormProps) {
           {allergensArray && (
             <div>
               <h4 className={`${styles.allergyHeader} omrs-bold`}>
-                Severity of worst reaction
+                {t("Severity of worst reaction", "Severity of worst reaction")}
               </h4>
               <div className={styles.container}>
                 <div className="omrs-radio-button">
@@ -395,12 +404,12 @@ export default function AllergyForm(props: AllergyFormProps) {
                     <input
                       type="radio"
                       name="reactionSeverity"
-                      value={AllergyConcepts.MILD_REACTION_SEVERITY}
+                      value={AllergyConcept.MILD_REACTION_SEVERITY}
                       onChange={evt =>
                         setReactionSeverityUuid(evt.target.value)
                       }
                     />
-                    <span>Mild</span>
+                    <span>{t("Mild", "Mild")}</span>
                   </label>
                 </div>
                 <div className="omrs-radio-button">
@@ -408,12 +417,12 @@ export default function AllergyForm(props: AllergyFormProps) {
                     <input
                       type="radio"
                       name="reactionSeverity"
-                      value={AllergyConcepts.MODERATE_REACTION_SEVERITY}
+                      value={AllergyConcept.MODERATE_REACTION_SEVERITY}
                       onChange={evt =>
                         setReactionSeverityUuid(evt.target.value)
                       }
                     />
-                    <span>Moderate</span>
+                    <span>{t("Moderate", "Moderate")}</span>
                   </label>
                 </div>
                 <div className="omrs-radio-button">
@@ -421,17 +430,19 @@ export default function AllergyForm(props: AllergyFormProps) {
                     <input
                       type="radio"
                       name="reactionSeverity"
-                      value={AllergyConcepts.SEVERE_REACTION_SEVERITY}
+                      value={AllergyConcept.SEVERE_REACTION_SEVERITY}
                       onChange={evt =>
                         setReactionSeverityUuid(evt.target.value)
                       }
                     />
-                    <span>Severe</span>
+                    <span>{t("Severe", "Severe")}</span>
                   </label>
                 </div>
               </div>
               <h4 className={`${styles.allergyHeader} omrs-bold`}>
-                <label htmlFor="first-onset-date">Date of first onset</label>
+                <label htmlFor="first-onset-date">
+                  {t("Date of first onset", "Date of first onset")}
+                </label>
               </h4>
               <div className={styles.dateContainer}>
                 <div className="omrs-datepicker">
@@ -460,7 +471,9 @@ export default function AllergyForm(props: AllergyFormProps) {
                     </div>
                   )}
               </div>
-              <h4 className={`${styles.allergyHeader} omrs-bold`}>Comments</h4>
+              <h4 className={`${styles.allergyHeader} omrs-bold`}>
+                {t("Comments", "Comments")}
+              </h4>
               <div className={styles.allergyCommentContainer}>
                 <textarea
                   className={`${styles.allergyCommentTextArea} omrs-type-body-regular`}
@@ -485,7 +498,7 @@ export default function AllergyForm(props: AllergyFormProps) {
               onClick={closeForm}
               style={{ width: "50%" }}
             >
-              Cancel
+              {t("Cancel", "Cancel")}
             </button>
             <button
               type="submit"
@@ -497,7 +510,7 @@ export default function AllergyForm(props: AllergyFormProps) {
               }
               disabled={!enableCreateButtons}
             >
-              Sign & Save
+              {t("Sign & Save", "Sign & Save")}
             </button>
           </div>
         </form>
@@ -508,7 +521,7 @@ export default function AllergyForm(props: AllergyFormProps) {
   function editAllergy() {
     return (
       <SummaryCard
-        name="Edit Allergy"
+        name={t("Edit existing allergy", "Edit existing allergy")}
         styles={{
           width: "100%",
           background: "var(--omrs-color-bg-medium-contrast)"
@@ -527,7 +540,7 @@ export default function AllergyForm(props: AllergyFormProps) {
               <div
                 className={`${styles.allergyEditHeader} omrs-padding-bottom-28`}
               >
-                <h4>Allergen</h4>
+                <h4>{t("Allergen", "Allergen")}</h4>
                 <h3>
                   {patientAllergy?.allergen?.codedAllergen?.display}{" "}
                   <span>
@@ -537,12 +550,12 @@ export default function AllergyForm(props: AllergyFormProps) {
               </div>
               <div>
                 <h4 className={`${styles.allergyHeader} omrs-bold`}>
-                  Reactions
+                  {t("Reactions", "Reactions")}
                 </h4>
                 <h4
                   className={`${styles.allergyHeader} omrs-type-body-regular`}
                 >
-                  Select all that apply
+                  {t("Select all that apply", "Select all that apply")}
                 </h4>
                 <div className={styles.container}>
                   {allergicReactions.map((reaction, index) => (
@@ -563,7 +576,10 @@ export default function AllergyForm(props: AllergyFormProps) {
               </div>
               <div>
                 <h4 className={`${styles.allergyHeader} omrs-bold`}>
-                  Severity of worst reaction
+                  {t(
+                    "Severity of worst reaction",
+                    "Severity of worst reaction"
+                  )}
                 </h4>
                 <div className={styles.container}>
                   <div className="omrs-radio-button">
@@ -571,16 +587,16 @@ export default function AllergyForm(props: AllergyFormProps) {
                       <input
                         type="radio"
                         name="reactionSeverity"
-                        defaultValue={AllergyConcepts.MILD_REACTION_SEVERITY}
+                        defaultValue={AllergyConcept.MILD_REACTION_SEVERITY}
                         defaultChecked={
                           patientAllergy?.severity?.uuid ===
-                          AllergyConcepts.MILD_REACTION_SEVERITY
+                          AllergyConcept.MILD_REACTION_SEVERITY
                         }
                         onChange={evt =>
                           setReactionSeverityUuid(evt.target.value)
                         }
                       />
-                      <span>Mild</span>
+                      <span>{t("Mild", "Mild")}</span>
                     </label>
                   </div>
                   <div className="omrs-radio-button">
@@ -588,18 +604,16 @@ export default function AllergyForm(props: AllergyFormProps) {
                       <input
                         type="radio"
                         name="reactionSeverity"
-                        defaultValue={
-                          AllergyConcepts.MODERATE_REACTION_SEVERITY
-                        }
+                        defaultValue={AllergyConcept.MODERATE_REACTION_SEVERITY}
                         defaultChecked={
                           patientAllergy?.severity?.uuid ===
-                          AllergyConcepts.MODERATE_REACTION_SEVERITY
+                          AllergyConcept.MODERATE_REACTION_SEVERITY
                         }
                         onChange={evt =>
                           setReactionSeverityUuid(evt.target.value)
                         }
                       />
-                      <span>Moderate</span>
+                      <span>{t("Moderate", "Moderate")}</span>
                     </label>
                   </div>
                   <div className="omrs-radio-button">
@@ -607,21 +621,23 @@ export default function AllergyForm(props: AllergyFormProps) {
                       <input
                         type="radio"
                         name="reactionSeverity"
-                        defaultValue={AllergyConcepts.SEVERE_REACTION_SEVERITY}
+                        defaultValue={AllergyConcept.SEVERE_REACTION_SEVERITY}
                         defaultChecked={
                           patientAllergy?.severity?.uuid ===
-                          AllergyConcepts.SEVERE_REACTION_SEVERITY
+                          AllergyConcept.SEVERE_REACTION_SEVERITY
                         }
                         onChange={evt =>
                           setReactionSeverityUuid(evt.target.value)
                         }
                       />
-                      <span>Severe</span>
+                      <span>{t("Severe", "Severe")}</span>
                     </label>
                   </div>
                 </div>
                 <h4 className={`${styles.allergyHeader} omrs-bold`}>
-                  <label htmlFor="first-onset-date">Date of first onset</label>
+                  <label htmlFor="first-onset-date">
+                    {t("Date of first onset", "Date of first onset")}
+                  </label>
                 </h4>
                 <div className={styles.dateContainer}>
                   <div className="omrs-datepicker">
@@ -653,9 +669,8 @@ export default function AllergyForm(props: AllergyFormProps) {
                       </div>
                     )}
                 </div>
-
                 <h4 className={`${styles.allergyHeader} omrs-bold`}>
-                  Comments
+                  {t("Comments", "Comments")}
                 </h4>
                 <div className={styles.allergyCommentContainer}>
                   <textarea
@@ -682,7 +697,7 @@ export default function AllergyForm(props: AllergyFormProps) {
                 style={{ width: "20%" }}
                 onClick={handleDeletePatientAllergy}
               >
-                Delete
+                {t("Delete", "Delete")}
               </button>
               <button
                 type="button"
@@ -690,7 +705,7 @@ export default function AllergyForm(props: AllergyFormProps) {
                 style={{ width: "30%" }}
                 onClick={closeForm}
               >
-                Cancel
+                {t("Cancel", "Cancel")}
               </button>
               <button
                 type="submit"
@@ -702,7 +717,7 @@ export default function AllergyForm(props: AllergyFormProps) {
                 style={{ width: "50%" }}
                 disabled={!enableEditButtons}
               >
-                Sign & Save
+                {t("Sign & Save", "Sign & Save")}
               </button>
             </div>
           </form>
@@ -725,7 +740,7 @@ AllergyForm.defaultProps = {
   closeComponent: () => {}
 };
 
-enum AllergyConcepts {
+enum AllergyConcept {
   DRUG_ALLERGEN = "162552AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
   ENVIRONMENTAL_ALLERGEN = "162554AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
   FOOD_ALLERGEN = "162553AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",

--- a/src/widgets/allergies/allergy-form.test.tsx
+++ b/src/widgets/allergies/allergy-form.test.tsx
@@ -83,9 +83,9 @@ describe("<AllergyForm />", () => {
       </BrowserRouter>
     );
 
-    await screen.findByText("Add New Allergy");
+    await screen.findByText("Record a new allergy");
 
-    expect(screen.getByText("Add New Allergy")).toBeInTheDocument();
+    expect(screen.getByText("Record a new allergy")).toBeInTheDocument();
     expect(screen.getByText("Category of reaction")).toBeInTheDocument();
     expect(screen.getByLabelText("Drug")).toBeInTheDocument();
     expect(screen.getByLabelText("Environmental")).toBeInTheDocument();
@@ -212,7 +212,7 @@ describe("<AllergyForm />", () => {
       </BrowserRouter>
     );
 
-    await screen.findByText("Edit Allergy");
+    await screen.findByText("Edit existing allergy");
 
     expect(screen.getByText("Allergen")).toBeInTheDocument();
     expect(

--- a/src/widgets/allergies/allergy-record.component.tsx
+++ b/src/widgets/allergies/allergy-record.component.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useRouteMatch } from "react-router-dom";
 import dayjs from "dayjs";
+import { useTranslation } from "react-i18next";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { openWorkspaceTab } from "../shared-utils";
@@ -14,6 +15,7 @@ export default function AllergyRecord(props: AllergyRecordProps) {
   const [allergy, setAllergy] = useState<Allergy>(null);
   const [isLoadingPatient, patient, patientUuid] = useCurrentPatient();
   const match = useRouteMatch();
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (!isLoadingPatient && patient && match.params["allergyUuid"]) {
@@ -31,13 +33,17 @@ export default function AllergyRecord(props: AllergyRecordProps) {
       {allergy && Object.entries(allergy).length && (
         <div className={styles.allergyContainer}>
           <SummaryCard
-            name="Allergy"
+            name={t("Allergy", "Allergy")}
             styles={{ width: "100%" }}
             editComponent={AllergyForm}
             showComponent={() =>
-              openWorkspaceTab(AllergyForm, "Edit Allergy", {
-                allergyUuid: allergy.id
-              })
+              openWorkspaceTab(
+                AllergyForm,
+                `${t("Edit Allergy", "Edit Allergy")}`,
+                {
+                  allergyUuid: allergy.id
+                }
+              )
             }
             link={`/patient/${patientUuid}/chart/allergies`}
           >
@@ -54,9 +60,9 @@ export default function AllergyRecord(props: AllergyRecordProps) {
               <table className={styles.allergyTable}>
                 <thead className="omrs-type-body-regular">
                   <tr>
-                    <th>Severity</th>
-                    <th>Reaction</th>
-                    <th>Onset Date</th>
+                    <th>{t("Severity", "Severity")}</th>
+                    <th>{t("Reaction", "Reaction")}</th>
+                    <th>{t("Onset Date", "Onset Date")}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -95,7 +101,7 @@ export default function AllergyRecord(props: AllergyRecordProps) {
                 <table className={styles.allergyTable}>
                   <thead className="omrs-type-body-regular">
                     <tr>
-                      <th>Comments</th>
+                      <th>{t("Comments", "Comments")}</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -109,30 +115,26 @@ export default function AllergyRecord(props: AllergyRecordProps) {
             </div>
           </SummaryCard>
           <RecordDetails>
-            <div className={styles.allergyCard}>
-              <table
-                className={`${styles.allergyTable} ${styles.allergyDetails}`}
-              >
-                <thead className="omrs-type-body-regular">
-                  <tr>
-                    <th>Last updated</th>
-                    <th>Last updated by</th>
-                    <th>Last updated location</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>
-                      {allergy.lastUpdated
-                        ? dayjs(allergy.lastUpdated).format("DD-MMM-YYYY")
-                        : "-"}
-                    </td>
-                    <td>{allergy.recordedBy}</td>
-                    <td>-</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
+            <table className={styles.allergyTable}>
+              <thead className="omrs-type-body-regular">
+                <tr>
+                  <th>{t("Last updated", "Last updated")}</th>
+                  <th>{t("Last updated by", "Last updated by")}</th>
+                  <th>{t("Last updated location", "Last updated location")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td style={{ fontFamily: "Work Sans" }}>
+                    {allergy.lastUpdated
+                      ? dayjs(allergy.lastUpdated).format("DD-MMM-YYYY")
+                      : "-"}
+                  </td>
+                  <td>{allergy.recordedBy}</td>
+                  <td>-</td>
+                </tr>
+              </tbody>
+            </table>
           </RecordDetails>
         </div>
       )}

--- a/src/widgets/allergies/allergy-record.css
+++ b/src/widgets/allergies/allergy-record.css
@@ -38,10 +38,6 @@
   font-family: "Work Sans";
 }
 
-.allergyDetails tbody td:nth-child(1) {
-  font-family: "Work Sans";
-}
-
 .allergyFooter {
   padding: 0.625rem;
 }


### PR DESCRIPTION
This PR adds translation keys to the components that make up the allergies widget as part of the i18n effort which can be followed here https://issues.openmrs.org/browse/MF-219.

It also discards an unnecessary div and two unused CSS classes from the details table in the AllergyRecord component.

<img width="1142" alt="Screenshot 2020-08-03 at 20 10 39" src="https://user-images.githubusercontent.com/8509731/89208880-e413d500-d5c5-11ea-98df-f435c4c6f77c.png">

<img width="1145" alt="Screenshot 2020-08-03 at 20 10 07" src="https://user-images.githubusercontent.com/8509731/89208889-e70ec580-d5c5-11ea-949a-05fe909b757d.png">
