### PR TITLE
MF-298: Allergy form onset date should not allow future dates

### DIFF
--- a/src/widgets/allergies/allergy-form.css
+++ b/src/widgets/allergies/allergy-form.css
@@ -80,3 +80,37 @@
 .buttonStylesBorder {
   border-top: 0.125rem solid var(--omrs-color-interaction);
 }
+
+.dateContainer {
+  display: grid;
+  background: var(--omrs-color-ink-white);
+  border: 0.0625rem solid var(--omrs-color-ink-low-contrast);
+  margin: 0rem 1rem 0.5rem 1rem;
+  padding: 1rem 0.5rem;
+}
+
+.dateContainer div {
+  margin-bottom: 0.5rem;
+}
+
+.dateError {
+  flex-direction: row;
+  box-sizing: border-box;
+  display: flex;
+  grid-row: 2;
+}
+
+.dateError span {
+  color: var(--omrs-color-danger);
+  line-height: 1.25rem;
+  font-size: 0.875rem;
+  white-space: normal;
+  display: inline;
+}
+
+.dateError svg {
+  fill: var(--omrs-color-danger);
+  height: 0.8rem;
+  width: 1.5rem;
+  padding-right: 0.25rem;
+}

--- a/src/widgets/allergies/allergy-form.test.tsx
+++ b/src/widgets/allergies/allergy-form.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { match, BrowserRouter } from "react-router-dom";
+import { match, useRouteMatch, BrowserRouter } from "react-router-dom";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import { mockPatient } from "../../../__mocks__/patient.mock";
 import {
@@ -28,6 +28,7 @@ const mockGetAllergicReactions = getAllergicReactions as jest.Mock;
 const mockGetAllergyAllergenByConceptUuid = getAllergyAllergenByConceptUuid as jest.Mock;
 const mockSavePatientAllergy = savePatientAllergy as jest.Mock;
 const mockUpdatePatientAllergy = updatePatientAllergy as jest.Mock;
+const mockUseRouteMatch = useRouteMatch as jest.Mock;
 
 jest.mock("./allergy-intolerance.resource", () => ({
   deletePatientAllergy: jest.fn(),
@@ -56,6 +57,7 @@ describe("<AllergyForm />", () => {
   beforeEach(() => {
     patient = mockPatient;
     mockUseCurrentPatient.mockReset;
+    mockUseRouteMatch.mockReset;
     mockDeletePatientAllergy.mockReset;
     mockGetPatientAllergyByPatientUuid.mockReset;
     mockGetAllergicReactions.mockReset;
@@ -120,6 +122,21 @@ describe("<AllergyForm />", () => {
     const submitBtn = screen.getByRole("button", { name: "Sign & Save" });
     expect(submitBtn).toBeInTheDocument();
     expect(submitBtn).not.toBeDisabled();
+
+    // Setting an invalid onset date should display an error
+    const onsetDateInput = await screen.findByLabelText("Date of first onset");
+    expect(onsetDateInput).toBeInTheDocument();
+
+    fireEvent.change(onsetDateInput, { target: { value: "2030-05-05" } });
+
+    expect(onsetDateInput).toBeInvalid();
+    await screen.findByText(
+      "Please enter a date that is either on or before today."
+    );
+    expect(screen.getByRole("button", { name: "Sign & Save" })).toBeDisabled();
+
+    // Set a valid onset date
+    fireEvent.change(onsetDateInput, { target: { value: "2020-01-01" } });
 
     window.confirm = jest.fn(() => true);
     // clicking Cancel prompts user for confirmation
@@ -225,6 +242,21 @@ describe("<AllergyForm />", () => {
 
     // modify form so formChanged becomes truthy
     fireEvent.click(screen.getByRole("radio", { name: "Moderate" }));
+
+    // Setting an invalid onset date should display an error
+    const onsetDateInput = await screen.findByLabelText("Date of first onset");
+    expect(onsetDateInput).toBeInTheDocument();
+
+    fireEvent.change(onsetDateInput, { target: { value: "2030-05-05" } });
+
+    expect(onsetDateInput).toBeInvalid();
+    await screen.findByText(
+      "Please enter a date that is either on or before today."
+    );
+    expect(screen.getByRole("button", { name: "Sign & Save" })).toBeDisabled();
+
+    // Set a valid updated onset date
+    fireEvent.change(onsetDateInput, { target: { value: "2020-06-05" } });
 
     window.confirm = jest.fn(() => true);
 

--- a/src/widgets/programs/programs-form.test.tsx
+++ b/src/widgets/programs/programs-form.test.tsx
@@ -27,7 +27,6 @@ import {
 } from "../../../__mocks__/programs.mock";
 import { mockSessionDataResponse } from "../../../__mocks__/session.mock";
 import { of } from "rxjs/internal/observable/of";
-import { update } from "lodash-es";
 
 const mockCreateProgramEnrollment = createProgramEnrollment as jest.Mock;
 const mockUseCurrentPatient = useCurrentPatient as jest.Mock;


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-298

This PR adds validation to the `Onset Date` input field on the Allergy Form to guard against entry of future dates. It constrains the date picker to display only valid dates by setting a `max` property to the current date. Should the user manually enter a future date, an error is displayed and the submit button is disabled. This validation works across both the Create Allergy form and the Edit Allergy form.

Screenshots:

Error state: Sign & Save button disabled and error message displayed beneath the Onset date field.
 
<img width="841" alt="Screenshot 2020-08-04 at 22 23 29" src="https://user-images.githubusercontent.com/8509731/89335780-23632400-d6a1-11ea-8e7f-583c5c55c38b.png">

Success state: Sign & Save button enabled and no error message is displayed.

<img width="842" alt="Screenshot 2020-08-04 at 22 21 50" src="https://user-images.githubusercontent.com/8509731/89335790-278f4180-d6a1-11ea-8f6d-1fa7b94a8c5a.png">
