### PR TITLE
MF-323: Fix allergy widget display property resolution

### DIFF
--- a/src/widgets/allergies/allergy-intolerance.resource.tsx
+++ b/src/widgets/allergies/allergy-intolerance.resource.tsx
@@ -20,18 +20,18 @@ export function performPatientAllergySearch(patientIdentifier: string) {
 }
 
 export function fetchAllergyByUuid(allergyUuid: string) {
-  return openmrsObservableFetch<Allergy>(
+  return openmrsObservableFetch(
     `${fhirBaseUrl}/AllergyIntolerance/${allergyUuid}`
   ).pipe(
     map(({ data }) => data),
-    map(data => mapAllergyProperties(data))
+    map((data: FHIRAllergy) => mapAllergyProperties(data))
   );
 }
 
-function mapAllergyProperties(allergy) {
+function mapAllergyProperties(allergy: FHIRAllergy): Allergy {
   let manifestations: Array<string> = [];
   allergy?.reaction[0]?.manifestation?.map(coding =>
-    manifestations.push(coding.coding[0].display)
+    manifestations.push(coding.coding[0]?.display)
   );
   const formattedAllergy: Allergy = {
     id: allergy?.id,

--- a/src/widgets/allergies/allergy-intolerance.resource.tsx
+++ b/src/widgets/allergies/allergy-intolerance.resource.tsx
@@ -31,13 +31,13 @@ export function fetchAllergyByUuid(allergyUuid: string) {
 function mapAllergyProperties(allergy) {
   let manifestations: Array<string> = [];
   allergy?.reaction[0]?.manifestation?.map(coding =>
-    manifestations.push(coding.coding[1].display)
+    manifestations.push(coding.coding[0].display)
   );
   const formattedAllergy: Allergy = {
     id: allergy?.id,
     clinicalStatus: allergy?.clinicalStatus?.coding[0]?.display,
     criticality: allergy?.criticality,
-    display: allergy?.code?.coding[1]?.display,
+    display: allergy?.code?.coding[0]?.display,
     recordedDate: allergy?.recordedDate,
     recordedBy: allergy?.recorder?.display,
     recorderType: allergy?.recorder?.type,

--- a/src/widgets/types.ts
+++ b/src/widgets/types.ts
@@ -104,7 +104,10 @@ export interface FHIRAllergy {
   };
   criticality: string;
   id: string;
-  note: [
+  meta?: {
+    lastUpdated: string;
+  };
+  note?: [
     {
       text: string;
     }
@@ -128,15 +131,23 @@ export interface FHIRAllergy {
     type: string;
   };
   resourceType: string;
+  text: {
+    div: string;
+    status: string;
+  };
   type: string;
 }
 
 interface FHIRAllergicReaction {
-  manifestation: CodingData[];
+  manifestation: FHIRAllergyManifestation[];
   severity: string;
   substance: {
     coding: CodingData[];
   };
+}
+
+interface FHIRAllergyManifestation {
+  coding: CodingData;
 }
 
 interface CodingData {


### PR DESCRIPTION
The display property for allergies is not working again following a backend tweak referenced here https://issues.openmrs.org/browse/FM2-298 which necessitates a change in the way we resolve the display concept on the frontend.

I've changed the way we access the deeply nested display property from the API response to get it back working.