### PR TITLE
MF-219: Add notes widget translations

### DIFF
--- a/src/widgets/notes/note-record.component.tsx
+++ b/src/widgets/notes/note-record.component.tsx
@@ -1,33 +1,36 @@
 import React, { useEffect, useState, Fragment } from "react";
-import { useRouteMatch } from "react-router-dom";
-import { useCurrentPatient } from "@openmrs/esm-api";
-import { fetchEncounterByUuid } from "./encounter.resource";
-import { createErrorHandler } from "@openmrs/esm-error-handling";
-import styles from "./note-record.css";
-import SummaryCard from "../../ui-components/cards/summary-card.component";
+import { match, useRouteMatch } from "react-router-dom";
 import dayjs from "dayjs";
+import { useTranslation } from "react-i18next";
+import { useCurrentPatient } from "@openmrs/esm-api";
+import { createErrorHandler } from "@openmrs/esm-error-handling";
+import SummaryCard from "../../ui-components/cards/summary-card.component";
 import RecordDetails from "../../ui-components/cards/record-details-card.component";
+import { fetchEncounterByUuid } from "./encounter.resource";
+import styles from "./note-record.css";
 
 export default function NoteRecord(props: NoteRecordProps) {
   const [note, setNote] = useState(null);
   const [isLoadingPatient, patient] = useCurrentPatient();
-  const match = useRouteMatch();
+  const match: match<TParams> = useRouteMatch();
+  const { params } = match;
+  const { t } = useTranslation();
 
   useEffect(() => {
-    if (!isLoadingPatient && patient && match.params) {
-      const sub = fetchEncounterByUuid(match.params["encounterUuid"]).subscribe(
+    if (!isLoadingPatient && patient && params) {
+      const sub = fetchEncounterByUuid(params["encounterUuid"]).subscribe(
         note => setNote(note),
         createErrorHandler()
       );
       return () => sub.unsubscribe();
     }
-  }, [isLoadingPatient, patient, match.params]);
+  }, [isLoadingPatient, patient, params]);
 
   return (
     <>
       {!!(note && Object.entries(note).length) && (
         <div className={styles.noteContainer}>
-          <SummaryCard name="Note" styles={{ width: "100%" }}>
+          <SummaryCard name={t("note", "Note")} styles={{ width: "100%" }}>
             <div className={`omrs-type-body-regular ${styles.noteCard}`}>
               <div>
                 <p className="omrs-type-title-3">{note?.display}</p>
@@ -35,9 +38,9 @@ export default function NoteRecord(props: NoteRecordProps) {
               <table className={styles.noteTable}>
                 <thead>
                   <tr>
-                    <td>Encounter type</td>
-                    <td>Location</td>
-                    <td>Encounter datetime</td>
+                    <td>{t("encounterType", "Encounter type")}</td>
+                    <td>{t("location", "Location")}</td>
+                    <td>{t("encounterDate", "Encounter date")}</td>
                   </tr>
                 </thead>
                 <tbody>
@@ -70,3 +73,7 @@ export default function NoteRecord(props: NoteRecordProps) {
 }
 
 type NoteRecordProps = {};
+
+type TParams = {
+  encounterUuid: string;
+};

--- a/src/widgets/notes/note-record.test.tsx
+++ b/src/widgets/notes/note-record.test.tsx
@@ -64,7 +64,7 @@ describe("<NoteRecord />", () => {
         wrapper.getByText("Visit Note 28/01/2015").textContent
       ).toBeTruthy();
       expect(wrapper.getByText("Encounter type").textContent).toBeTruthy();
-      expect(wrapper.getByText("Encounter datetime").textContent).toBeTruthy();
+      expect(wrapper.getByText("Encounter date").textContent).toBeTruthy();
       expect(wrapper.getByText("Location").textContent).toBeTruthy();
       expect(wrapper.getByText("Visit Note").textContent).toBeTruthy();
       expect(wrapper.getByText("Unknown Location").textContent).toBeTruthy();
@@ -103,7 +103,7 @@ describe("<NoteRecord />", () => {
         wrapper.getByText("Visit Note 28/01/2015").textContent
       ).toBeTruthy();
       expect(wrapper.getByText("Encounter type").textContent).toBeTruthy();
-      expect(wrapper.getByText("Encounter datetime").textContent).toBeTruthy();
+      expect(wrapper.getByText("Encounter date").textContent).toBeTruthy();
       expect(wrapper.getByText("Location").textContent).toBeTruthy();
       expect(wrapper.getByText("Visit Note").textContent).toBeTruthy();
       expect(wrapper.getByText("Unknown Location").textContent).toBeTruthy();

--- a/src/widgets/notes/notes-detailed-summary.component.tsx
+++ b/src/widgets/notes/notes-detailed-summary.component.tsx
@@ -1,16 +1,16 @@
 import React, { useState, useEffect, Fragment } from "react";
 import { useRouteMatch, Link } from "react-router-dom";
-import SummaryCard from "../../ui-components/cards/summary-card.component";
-import styles from "./notes-detailed-summary.css";
-import { useCurrentPatient } from "@openmrs/esm-api";
-import { getEncounterObservableRESTAPI } from "./encounter.resource";
-import { createErrorHandler } from "@openmrs/esm-error-handling";
-import { formatDate } from "../heightandweight/heightandweight-helper";
+import { capitalize, isEmpty } from "lodash-es";
 import { useTranslation } from "react-i18next";
+import { useCurrentPatient } from "@openmrs/esm-api";
+import { createErrorHandler } from "@openmrs/esm-error-handling";
+import SummaryCard from "../../ui-components/cards/summary-card.component";
+import { getEncounterObservableRESTAPI } from "./encounter.resource";
+import { formatDate } from "../heightandweight/heightandweight-helper";
 import VisitNotes from "./visit-note.component";
-import { isEmpty } from "lodash-es";
 import { openWorkspaceTab } from "../shared-utils";
 import { PatientNotes } from "../types";
+import styles from "./notes-detailed-summary.css";
 import EmptyState from "../../ui-components/empty-state/empty-state.component";
 
 function NotesDetailedSummary(props: NotesDetailedSummaryProps) {
@@ -54,15 +54,6 @@ function NotesDetailedSummary(props: NotesDetailedSummaryProps) {
     }
   }, [patientNotes, currentPageResults, currentPage]);
 
-  function toTitleCase(string: string) {
-    if (string) {
-      let results = string.split(" ").map(word => {
-        return word[0].toUpperCase() + word.slice(1);
-      });
-      return results.join(" ");
-    }
-  }
-
   const nextPage = () => {
     let upperBound = currentPage * resultsPerPage + resultsPerPage;
     const lowerBound = currentPage * resultsPerPage;
@@ -93,10 +84,13 @@ function NotesDetailedSummary(props: NotesDetailedSummaryProps) {
       >
         <table className={`omrs-type-body-regular ${styles.notesTable}`}>
           <thead>
-            <tr className={styles.notesTableRow}>
-              <th>DATE</th>
+            <tr
+              className={styles.notesTableRow}
+              style={{ textTransform: "uppercase" }}
+            >
+              <th>{t("date", "Date")}</th>
               <th style={{ textAlign: "left" }}>
-                NOTE
+                {t("note", "Note")}
                 <svg
                   className="omrs-icon"
                   style={{
@@ -106,9 +100,11 @@ function NotesDetailedSummary(props: NotesDetailedSummaryProps) {
                 >
                   <use xlinkHref="#omrs-icon-arrow-downward"></use>
                 </svg>
-                <span style={{ marginLeft: "1.25rem" }}>LOCATION</span>
+                <span style={{ marginLeft: "1.25rem" }}>
+                  {t("location", "Location")}
+                </span>
               </th>
-              <th style={{ textAlign: "left" }}>AUTHOR</th>
+              <th style={{ textAlign: "left" }}>{t("author", "Author")}</th>
               <th></th>
             </tr>
           </thead>
@@ -123,7 +119,7 @@ function NotesDetailedSummary(props: NotesDetailedSummaryProps) {
                       </td>
                       <td className={styles.noteInfo}>
                         <span className="omrs-medium">
-                          {note?.encounterType?.name}
+                          {note.encounterType?.name}
                         </span>
                         <div
                           style={{
@@ -131,12 +127,13 @@ function NotesDetailedSummary(props: NotesDetailedSummaryProps) {
                             margin: "0rem"
                           }}
                         >
-                          {toTitleCase(note?.location?.name)}
+                          {capitalize(note.location?.display)}
                         </div>
                       </td>
                       <td className={styles.noteAuthor}>
                         {!isEmpty(note.encounterProviders)
-                          ? note?.encounterProviders[0].provider.person.display
+                          ? note.encounterProviders[0]?.provider?.person
+                              ?.display
                           : "\u2014"}
                       </td>
                       <td
@@ -170,7 +167,7 @@ function NotesDetailedSummary(props: NotesDetailedSummaryProps) {
                 >
                   <use xlinkHref="#omrs-icon-chevron-left" />
                 </svg>
-                Previous
+                {t("previous", "Previous")}
               </button>
             )}
           </div>
@@ -180,12 +177,12 @@ function NotesDetailedSummary(props: NotesDetailedSummaryProps) {
               style={{ fontFamily: "Work Sans" }}
             >
               <p style={{ color: "var(--omrs-color-ink-medium-contrast)" }}>
-                No more notes available
+                {t("noMoreNotesAvailable", "No more notes available")}
               </p>
             </div>
           ) : (
             <div>
-              Page {currentPage} of {totalPages}
+              {t("page", "Page")} {currentPage} {t("of", "of")} {totalPages}
             </div>
           )}
           <div>
@@ -194,7 +191,7 @@ function NotesDetailedSummary(props: NotesDetailedSummaryProps) {
                 onClick={nextPage}
                 className={`${styles.navButton} omrs-bold omrs-btn omrs-text-neutral omrs-rounded`}
               >
-                Next
+                {t("next", "Next")}
                 <svg
                   className="omrs-icon"
                   fill="var(--omrs-color-ink-low-contrast)"
@@ -217,12 +214,12 @@ function NotesDetailedSummary(props: NotesDetailedSummaryProps) {
             displayPatientNotes()
           ) : (
             <EmptyState
-              name={t("Notes")}
-              displayText={t("visitNotes", "visit notes")}
+              name={t("notes", "Notes")}
               showComponent={() =>
-                openWorkspaceTab(VisitNotes, `${t("Visit Notes Form")}`)
+                openWorkspaceTab(VisitNotes, `${t("visitNote", "Visit Note")}`)
               }
               addComponent={VisitNotes}
+              displayText={t("notes", "notes")}
             />
           )}
         </div>

--- a/src/widgets/notes/notes-detailed-summary.test.tsx
+++ b/src/widgets/notes/notes-detailed-summary.test.tsx
@@ -1,13 +1,12 @@
 import React from "react";
+import { BrowserRouter } from "react-router-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { of } from "rxjs";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import { getEncounterObservableRESTAPI } from "./encounter.resource";
-import { cleanup, render, fireEvent } from "@testing-library/react";
 import { mockPatient } from "../../../__mocks__/patient.mock";
 import { mockPatientEncountersRESTAPI } from "../../../__mocks__/encounters.mock";
-import { BrowserRouter } from "react-router-dom";
 import NotesDetailedSummary from "./notes-detailed-summary.component";
-import { of } from "rxjs";
-import { act } from "react-dom/test-utils";
 
 const mockGetEncounterObservableRESTAPI = getEncounterObservableRESTAPI as jest.Mock;
 const mockUseCurrentPatient = useCurrentPatient as jest.Mock;
@@ -20,12 +19,18 @@ jest.mock("./encounter.resource", () => ({
   getEncounterObservableRESTAPI: jest.fn()
 }));
 
+jest.mock("lodash", () => ({
+  capitalize: jest
+    .fn()
+    .mockImplementation(s => s.charAt(0).toUpperCase() + s.slice(1)),
+  isEmpty: jest.fn().mockImplementation(arr => arr.length === 0)
+}));
+
 describe("<NotesDetailedSummary />", () => {
   let patient: fhir.Patient = mockPatient;
   afterEach(() => {
     mockUseCurrentPatient.mockReset();
     mockGetEncounterObservableRESTAPI.mockReset();
-    cleanup();
   });
 
   beforeEach(() => {
@@ -35,75 +40,33 @@ describe("<NotesDetailedSummary />", () => {
     );
   });
 
-  it("renders without dying", () => {
-    const wrapper = render(
-      <BrowserRouter>
-        <NotesDetailedSummary />
-      </BrowserRouter>
-    );
-  });
-
-  it("displays the notes correctly", () => {
-    const { getByText, container } = render(
-      <BrowserRouter>
-        <NotesDetailedSummary />
-      </BrowserRouter>
-    );
-    expect(getByText("Notes")).toBeTruthy();
-    expect(getByText(/19-Feb/)).toBeTruthy();
-    expect(getByText("Isolation Ward")).toBeTruthy();
-    expect(getByText("JJ Dick")).toBeTruthy();
-    expect(getByText("Page 1 of 3")).toBeTruthy();
-  });
-
-  it("should display the pagination controls", () => {
-    const { getByText } = render(
+  it("displays the notes correctly", async () => {
+    render(
       <BrowserRouter>
         <NotesDetailedSummary />
       </BrowserRouter>
     );
 
-    expect(getByText("Next")).toBeTruthy();
-    expect(getByText("Page 1 of 3")).toBeTruthy();
-  });
-
-  it("navigates to next and previous page of results", () => {
-    const { getByText } = render(
-      <BrowserRouter>
-        <NotesDetailedSummary />
-      </BrowserRouter>
-    );
-
-    const nextButton = getByText("Next");
-
-    expect(getByText("Page 1 of 3")).toBeTruthy();
-    expect(getByText("Next")).toBeDefined();
-
-    act(() => {
-      fireEvent.click(nextButton);
-    });
-
-    expect(getByText("Page 2 of 3")).toBeDefined();
-    expect(getByText("Previous")).toBeDefined();
-
-    const previousButton = getByText("Previous");
-    const pageTwoNextButton = getByText("Next");
-
-    act(() => {
-      fireEvent.click(pageTwoNextButton);
-    });
-
-    expect(getByText("Page 3 of 3")).toBeTruthy();
-    expect(getByText("Previous")).toBeTruthy();
-
-    const pageThreePreviousButton = getByText("Previous");
-
-    act(() => {
-      fireEvent.click(pageThreePreviousButton);
-    });
-
-    expect(getByText("Page 2 of 3")).toBeTruthy();
-    expect(getByText("Previous")).toBeTruthy();
-    expect(getByText("Next")).toBeTruthy();
+    await expect(
+      screen.getByRole("heading", { name: "Notes" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+    expect(screen.getByText("Date")).toBeInTheDocument();
+    expect(screen.getByText("Note")).toBeInTheDocument();
+    expect(screen.getByText("Location")).toBeInTheDocument();
+    expect(screen.getByText("Author")).toBeInTheDocument();
+    expect(screen.getByText(/19-Feb/)).toBeInTheDocument();
+    expect(screen.getByText("Isolation Ward")).toBeInTheDocument();
+    expect(screen.getByText("JJ Dick")).toBeInTheDocument();
+    expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+    const nextButton = screen.getByRole("button", { name: "Next" });
+    expect(nextButton).toBeInTheDocument();
+    fireEvent.click(nextButton);
+    const prevButton = screen.getByRole("button", { name: "Previous" });
+    expect(prevButton).toBeInTheDocument();
+    expect(screen.getByText("Page 2 of 3")).toBeInTheDocument();
+    fireEvent.click(nextButton);
+    expect(screen.getByText("Page 3 of 3")).toBeInTheDocument();
+    expect(nextButton).not.toBeInTheDocument();
   });
 });

--- a/src/widgets/notes/notes-overview.component.tsx
+++ b/src/widgets/notes/notes-overview.component.tsx
@@ -1,29 +1,24 @@
 import React from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useCurrentPatient } from "@openmrs/esm-api";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { getEncounterObservableRESTAPI } from "./encounter.resource";
-import styles from "./notes-overview.css";
-import { useCurrentPatient } from "@openmrs/esm-api";
-import { Link } from "react-router-dom";
 import { formatNotesDate } from "./notes-helper";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import SummaryCardFooter from "../../ui-components/cards/summary-card-footer.component";
 import EmptyState from "../../ui-components/empty-state/empty-state.component";
-import { useTranslation } from "react-i18next";
 import useChartBasePath from "../../utils/use-chart-base";
 import { PatientNotes } from "../types";
 import { openWorkspaceTab } from "../shared-utils";
 import VisitNotes from "./visit-note.component";
+import styles from "./notes-overview.css";
 
-export default function NotesOverview(props: NotesOverviewProps) {
+export default function NotesOverview({ basePath }: NotesOverviewProps) {
   const [patientNotes, setPatientNotes] = React.useState<Array<PatientNotes>>();
-  const [
-    isLoadingPatient,
-    patient,
-    patientUuid,
-    patientErr
-  ] = useCurrentPatient();
+  const [, patient, patientUuid] = useCurrentPatient();
   const chartBasePath = useChartBasePath();
-  const notesPath = chartBasePath + "/" + props.basePath;
+  const notesPath = chartBasePath + "/" + basePath;
   const { t } = useTranslation();
 
   React.useEffect(() => {
@@ -51,9 +46,12 @@ export default function NotesOverview(props: NotesOverviewProps) {
           <table className={`omrs-type-body-regular ${styles.notesTable}`}>
             <thead>
               <tr className={styles.notesTableRow}>
-                <th>Date</th>
-                <th style={{ textAlign: "left" }}>Encounter type, Location</th>
-                <th style={{ textAlign: "left" }}>Author</th>
+                <th>{t("date", "Date")}</th>
+                <th style={{ textAlign: "left" }}>
+                  {t("encounterType", "Encounter type")},{" "}
+                  {t("location", "Location")}
+                </th>
+                <th style={{ textAlign: "left" }}>{t("author", "author")}</th>
                 <th></th>
               </tr>
             </thead>

--- a/src/widgets/notes/visit-note.component.tsx
+++ b/src/widgets/notes/visit-note.component.tsx
@@ -1,18 +1,18 @@
-import React, { useState, useEffect, useRef, Fragment } from "react";
+import React, { useState, useEffect, useRef } from "react";
+import dayjs from "dayjs";
+import { debounce } from "lodash";
+import { isEmpty, remove } from "lodash-es";
+import { useTranslation } from "react-i18next";
+import { createErrorHandler } from "@openmrs/esm-error-handling";
+import { useCurrentPatient } from "@openmrs/esm-api";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
-import styles from "./visit-note.css";
 import {
-  fetchAllLoccations,
+  fetchAllLocations,
   fetchAllProviders,
   fetchDiagnosisByName,
   fetchCurrentSessionData,
   saveVisitNote
 } from "./visit-notes.resource";
-import { createErrorHandler } from "@openmrs/esm-error-handling";
-import dayjs from "dayjs";
-import { debounce } from "lodash";
-import { isEmpty, remove } from "lodash-es";
-import { useCurrentPatient } from "@openmrs/esm-api";
 import {
   diagnosisType,
   obs,
@@ -20,6 +20,7 @@ import {
   convertToObsPayLoad
 } from "./visit-note.util";
 import { DataCaptureComponentProps } from "../shared-utils";
+import styles from "./visit-note.css";
 
 const FORM_CONCEPT: string = "c75f120a-04ec-11e3-8780-2b40bef9a44b";
 const ENCOUNTER_TYPE: string = "d7151f82-c1f3-4152-a605-2f9ea7414a79";
@@ -27,26 +28,27 @@ const ENCOUNTER_NOTE_CONCEPT: string = "162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 const CLINICIAN_ENCOUNTER_ROLE: string = "240b26f9-dd88-4172-823d-4a8bfeb7841f";
 
 export default function VisitNotes(props: VisitNotesProp) {
+  const { t } = useTranslation();
   const searchTimeOut = 300;
+  const searchTermRef = useRef<HTMLInputElement>();
   const [locations, setLocations] = useState([]);
   const [providers, setProviders] = useState([]);
   const [visitDate, setVisitDate] = useState(new Date());
   const [searchTerm, setSearchTerm] = useState<string>("");
   const [searchResults, setSearchResults] = useState(null);
-  const searchTermRef = useRef<HTMLInputElement>();
   const [currentSession, setCurrentSession] = useState(null);
   const [selectedProvider, setSelectedProvider] = useState(null);
   const [selectedLocation, setSelectedLocation] = useState(null);
   const [diagnosisArray, setDiagnosisArray] = useState<diagnosisType[]>([]);
   const [diagnosisChanged, setDiagnosisChanged] = useState<boolean>();
   const [clinicalNote, setClinicalNote] = useState<string>("");
-  const [isLoadingPatient, patient, patientUuid] = useCurrentPatient();
+  const [, , patientUuid] = useCurrentPatient();
   const [formChanged, setFormChanged] = useState<Boolean>(false);
   const [saveButtonStatus, setSaveButtonStatus] = useState<boolean>(false);
 
   useEffect(() => {
     const abortController = new AbortController();
-    fetchAllLoccations(abortController).then(
+    fetchAllLocations(abortController).then(
       ({ data }) => setLocations(data.results),
       createErrorHandler()
     );
@@ -218,8 +220,8 @@ export default function VisitNotes(props: VisitNotesProp) {
   };
 
   return (
-    <SummaryCard name="Visit Note">
-      {selectedLocation && selectedProvider && (
+    <SummaryCard name={t("visitNote", "Visit Note")}>
+      {selectedLocation && (
         <form
           className={styles.visitNoteFormContainer}
           autoComplete="off"
@@ -234,7 +236,7 @@ export default function VisitNotes(props: VisitNotesProp) {
             style={{ marginBottom: "1.5rem" }}
           >
             <div className={styles.visitNotesInputContainer}>
-              <label htmlFor="provider">Provider</label>
+              <label htmlFor="provider">{t("provider", "Provider")}</label>
               <select
                 name="provider"
                 id="provider"
@@ -259,7 +261,7 @@ export default function VisitNotes(props: VisitNotesProp) {
               </select>
             </div>
             <div className={styles.visitNotesInputContainer}>
-              <label htmlFor="location">Location</label>
+              <label htmlFor="location">{t("location", "Location")}</label>
               <select
                 name="location"
                 id="location"
@@ -279,7 +281,7 @@ export default function VisitNotes(props: VisitNotesProp) {
             </div>
             <div className={styles.visitNotesInputContainer}>
               <label htmlFor="date">
-                Date{" "}
+                {t("date", "Date")}{" "}
                 <small
                   style={{
                     fontWeight: "normal",
@@ -315,7 +317,10 @@ export default function VisitNotes(props: VisitNotesProp) {
             >
               <div className={styles.visitNotesInputContainer}>
                 <label htmlFor="diagnosis">
-                  Add presumed or confirmed diagnosis (required):
+                  {t(
+                    "addDiagnosis",
+                    "Add presumed or confirmed diagnosis (required):"
+                  )}
                 </label>
                 <input
                   type="text"
@@ -350,7 +355,9 @@ export default function VisitNotes(props: VisitNotesProp) {
                 </div>
               </div>
               <div className={styles.visitNotesInputContainer}>
-                <label htmlFor="clinicalNote">Clinical Note</label>
+                <label htmlFor="clinicalNote">
+                  {t("clinicalNote", "Clinical Note")}
+                </label>
                 <textarea
                   name="clinicalNote"
                   id="clinicalNote"
@@ -360,10 +367,9 @@ export default function VisitNotes(props: VisitNotesProp) {
                 ></textarea>
               </div>
             </div>
-
             <div className={styles.diagnosisContainer}>
               <div>
-                <span>Primary Diagnosis:</span>
+                <span>{t("primaryDiagnosis", "Primary Diagnosis:")}</span>
                 <hr />
                 {!isEmpty(
                   diagnosisArray.filter(diagnosis => diagnosis.primary === true)
@@ -401,7 +407,9 @@ export default function VisitNotes(props: VisitNotesProp) {
                                         handlePrimaryChange(diagnosis)
                                       }
                                     />
-                                    <label htmlFor="primary">Primary</label>
+                                    <label htmlFor="primary">
+                                      {t("primary", "Primary")}
+                                    </label>
                                   </div>
                                   <div>
                                     <input
@@ -413,7 +421,9 @@ export default function VisitNotes(props: VisitNotesProp) {
                                         handleDiagnosisChange(diagnosis)
                                       }
                                     />
-                                    <label htmlFor="confirmed">Confirmed</label>
+                                    <label htmlFor="confirmed">
+                                      {t("confirmed", "Confirmed")}
+                                    </label>
                                   </div>
                                 </div>
                               </div>
@@ -433,11 +443,13 @@ export default function VisitNotes(props: VisitNotesProp) {
                         ))}
                   </div>
                 ) : (
-                  <div style={{ marginBottom: "1.625rem" }}>Not chosen</div>
+                  <div style={{ marginBottom: "1.625rem" }}>
+                    {t("notChosen", "Not chosen")}
+                  </div>
                 )}
               </div>
               <div>
-                <span>Secondary Diagnoses:</span>
+                <span>{t("secondaryDiagnoses", "Secondary Diagnoses:")}</span>
                 <hr />
                 {!isEmpty(
                   diagnosisArray.filter(
@@ -482,7 +494,9 @@ export default function VisitNotes(props: VisitNotesProp) {
                                           handlePrimaryChange(diagnosis)
                                         }
                                       />
-                                      <label htmlFor="primary">Primary</label>
+                                      <label htmlFor="primary">
+                                        {t("primary", "Primary")}
+                                      </label>
                                     </div>
                                     <div>
                                       <input
@@ -495,7 +509,7 @@ export default function VisitNotes(props: VisitNotesProp) {
                                         }
                                       />
                                       <label htmlFor="confirmed">
-                                        Confirmed
+                                        {t("confirmed", "Confirmed")}
                                       </label>
                                     </div>
                                   </div>
@@ -519,7 +533,9 @@ export default function VisitNotes(props: VisitNotesProp) {
                         })}
                   </>
                 ) : (
-                  <div style={{ marginBottom: "1.625rem" }}>None</div>
+                  <div style={{ marginBottom: "1.625rem" }}>
+                    {t("none", "None")}
+                  </div>
                 )}
               </div>
             </div>
@@ -530,7 +546,7 @@ export default function VisitNotes(props: VisitNotesProp) {
               onClick={exitForm}
               className="omrs-btn omrs-outlined-neutral"
             >
-              Cancel
+              {t("cancel", "Cancel")}
             </button>
             <button
               type="submit"
@@ -541,7 +557,7 @@ export default function VisitNotes(props: VisitNotesProp) {
               }`}
               disabled={saveButtonStatus}
             >
-              Save
+              {t("save", "Save")}
             </button>
           </div>
         </form>

--- a/src/widgets/notes/visit-note.test.tsx
+++ b/src/widgets/notes/visit-note.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { BrowserRouter } from "react-router-dom";
 import VisitsNote from "./visit-note.component";
 import {
-  fetchAllLoccations,
+  fetchAllLocations,
   fetchAllProviders,
   fetchCurrentSessionData,
   fetchDiagnosisByName
@@ -19,14 +19,14 @@ import { screen, render, fireEvent, wait } from "@testing-library/react";
 import { of } from "rxjs";
 import { act } from "react-dom/test-utils";
 
-const mockFetchAllLocations = fetchAllLoccations as jest.Mock;
+const mockFetchAllLocations = fetchAllLocations as jest.Mock;
 const mockFetchAllProviders = fetchAllProviders as jest.Mock;
 const mockFetchCurrentSessionsData = fetchCurrentSessionData as jest.Mock;
 const mockUseCurrentPatient = useCurrentPatient as jest.Mock;
 const mockFetchDiagnosisByName = fetchDiagnosisByName as jest.Mock;
 
 jest.mock("./visit-notes.resource", () => ({
-  fetchAllLoccations: jest.fn(),
+  fetchAllLocations: jest.fn(),
   fetchAllProviders: jest.fn(),
   fetchCurrentSessionData: jest.fn(),
   fetchDiagnosisByName: jest.fn()
@@ -74,7 +74,7 @@ describe("<VisitNote>", () => {
     expect(await screen.findByText(/Visit Note/)).toBeTruthy();
     expect(await screen.findByText("User 2")).toBeTruthy();
     expect(await screen.findByText("Inpatient Ward")).toBeTruthy();
-    expect(fetchAllLoccations).toHaveBeenCalled();
+    expect(fetchAllLocations).toHaveBeenCalled();
     expect(fetchAllProviders).toHaveBeenCalled();
   });
 

--- a/src/widgets/notes/visit-notes.resource.tsx
+++ b/src/widgets/notes/visit-notes.resource.tsx
@@ -2,7 +2,7 @@ import { openmrsFetch, openmrsObservableFetch } from "@openmrs/esm-api";
 import { map } from "rxjs/operators";
 import { visitNotePayload } from "./visit-note.util";
 
-export function fetchAllLoccations(abortController: AbortController) {
+export function fetchAllLocations(abortController: AbortController) {
   return openmrsFetch("/ws/rest/v1/location?v=custom:(uuid,display)", {
     signal: abortController.signal
   });

--- a/src/widgets/shared-utils.tsx
+++ b/src/widgets/shared-utils.tsx
@@ -30,11 +30,6 @@ export function openWorkspaceTab<
   }
 }
 
-export function capitalize(s): string {
-  if (typeof s !== "string") return "";
-  return s.charAt(0).toUpperCase() + s.slice(1);
-}
-
 export type DataCaptureComponentProps = {
   entryStarted: () => void;
   entrySubmitted: () => void;


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-219

- Adds translation keys to the components that make up the notes widget.

![Screenshot 2020-09-22 at 14 30 26](https://user-images.githubusercontent.com/8509731/93877581-55782600-fce1-11ea-9fac-f5845ef84ec8.png)

![Screenshot 2020-09-22 at 14 29 46](https://user-images.githubusercontent.com/8509731/93877619-5d37ca80-fce1-11ea-871b-bba41cd2039c.png)

![Screenshot 2020-09-22 at 14 28 45](https://user-images.githubusercontent.com/8509731/93877644-645ed880-fce1-11ea-9673-01fe4ce65869.png)

![Screenshot 2020-09-22 at 14 02 06](https://user-images.githubusercontent.com/8509731/93877664-6d4faa00-fce1-11ea-9d95-6774cd653e89.png)

![Screenshot 2020-09-22 at 14 28 45](https://user-images.githubusercontent.com/8509731/93877647-65900580-fce1-11ea-89f1-00002d7137cd.png)

