### PR TITLE
MF-219: Add visits widget translations

### DIFF
--- a/__mocks__/visits.mock.ts
+++ b/__mocks__/visits.mock.ts
@@ -7,7 +7,7 @@ export const mockVisitTypes = [
   {
     uuid: "some-uuid2",
     name: "HIV Return Visit",
-    display: "Outpatient Visit"
+    display: "HIV Return Visit"
   }
 ];
 

--- a/src/widgets/visit/edit-visit.component.tsx
+++ b/src/widgets/visit/edit-visit.component.tsx
@@ -1,15 +1,15 @@
 import React, { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import dayjs from "dayjs";
 import styles from "./edit-visit.css";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
-import dayjs from "dayjs";
 import { getStartedVisit, visitMode, visitStatus } from "./visit-utils";
-import { useTranslation } from "react-i18next";
 import { getVisitsForPatient, Visit } from "./visit.resource";
 
 export default function EditVisit(props: EditVisitProps) {
   const [patientVisits, setPatientVisits] = useState<Array<Visit>>([]);
-  const [isLoadingPatient, patient, patientUuid] = useCurrentPatient();
+  const [, , patientUuid] = useCurrentPatient();
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -46,7 +46,7 @@ export default function EditVisit(props: EditVisitProps) {
                 <tr key={visit.uuid}>
                   <td>{formatVisitDate(visit.startDatetime)}</td>
                   <td>{visit.visitType.display}</td>
-                  <td>{visit?.location?.display}</td>
+                  <td>{visit.location?.display}</td>
                   <td>
                     {visit.stopDatetime
                       ? formatVisitDate(visit.stopDatetime)
@@ -59,7 +59,7 @@ export default function EditVisit(props: EditVisitProps) {
                       onClick={() => {
                         props.onVisitStarted();
                         getStartedVisit.next({
-                          mode: visitMode.EDITVISI,
+                          mode: visitMode.EDITVISIT,
                           visitData: visit,
                           status: visitStatus.ONGOING
                         });

--- a/src/widgets/visit/end-visit-prompt.component.test.tsx
+++ b/src/widgets/visit/end-visit-prompt.component.test.tsx
@@ -24,7 +24,7 @@ const mockCurrentVisit = {
 };
 
 describe("End Visit Prompt", () => {
-  it("Renders end visit prompt", () => {
+  it("renders end visit prompt", () => {
     render(<EndVisit currentVisit={mockCurrentVisit} />);
 
     expect(

--- a/src/widgets/visit/new-visit.component.test.tsx
+++ b/src/widgets/visit/new-visit.component.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import dayjs from "dayjs";
-import { render, cleanup, fireEvent } from "@testing-library/react";
-import { screen } from "@testing-library/dom";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { of } from "rxjs";
 import { mockVisitTypesDataResponse } from "../../../__mocks__/visits.mock";
 import { mockLocationsDataResponse } from "../../../__mocks__/location.mock";
@@ -24,7 +23,6 @@ jest.mock("@openmrs/esm-api", () => ({
 describe("<NewVisit />", () => {
   let patientUuid = "some-patient-uuid";
 
-  afterEach(cleanup);
   afterEach(mockOpenmrsObservableFetch.mockReset);
   afterEach(mockGetCurrentPatientUuid.mockReset);
   beforeEach(() => {
@@ -49,7 +47,7 @@ describe("<NewVisit />", () => {
   });
 
   it("renders and default values are selected", () => {
-    const { queryByLabelText, getByDisplayValue } = render(
+    render(
       <NewVisit
         onVisitStarted={() => {}}
         onCanceled={() => {}}
@@ -57,13 +55,23 @@ describe("<NewVisit />", () => {
         viewMode={true}
       />
     );
-    expect(queryByLabelText(/Type of visit/i)).toBeTruthy();
-    expect(queryByLabelText(/Start date\/time/i)).toBeTruthy();
-    expect(queryByLabelText(/location/i)).toBeTruthy();
-    expect(queryByLabelText(/Start/i)).toBeTruthy();
-
+    expect(
+      screen.getByRole("heading", { name: "Start new visit" })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/Type of visit/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Start date/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Start time/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/location/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Outpatient Visit" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "HIV Return Visit" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
     // check for default selected location being the session location
-    expect(getByDisplayValue(/Inpatient Ward/i)).toBeTruthy();
+    expect(screen.getByDisplayValue(/Inpatient Ward/i)).toBeInTheDocument();
   });
 
   it("starts or cancels a new visit", async () => {
@@ -71,7 +79,7 @@ describe("<NewVisit />", () => {
     const mockCancelledCallback = jest.fn();
     const mockCloseComponent = jest.fn();
 
-    const { getByLabelText, getByTestId, container } = render(
+    render(
       <NewVisit
         onVisitStarted={mockStartedCallback}
         onCanceled={mockCancelledCallback}
@@ -87,20 +95,20 @@ describe("<NewVisit />", () => {
       .set("millisecond", 0);
 
     // simulate visit type selection
-    const visitTypeSelect = getByLabelText(/Type of visit/i);
+    const visitTypeSelect = screen.getByLabelText(/Type of visit/i);
     fireEvent.change(visitTypeSelect, { target: { value: "some-uuid1" } });
 
     // simulate location selection
-    const locationSelect = getByLabelText(/location/i);
+    const locationSelect = screen.getByLabelText(/location/i);
     fireEvent.change(locationSelect, { target: { value: "some-uuid1" } });
 
     // simulate date selection
-    const dateControl = getByTestId("date-select");
+    const dateControl = screen.getByLabelText("Start date");
     fireEvent.change(dateControl, {
       target: { value: testDate.format("YYYY-MM-DD") }
     });
 
-    const timeControl = getByTestId("time-select");
+    const timeControl = screen.getByLabelText("Start time");
     fireEvent.change(timeControl, {
       target: { value: testDate.format("HH:mm") }
     });
@@ -133,7 +141,7 @@ describe("<NewVisit />", () => {
     ).toBe(true);
 
     // simulate cancelling
-    const cancelButton = await screen.findByText("Cancel");
+    const cancelButton = await screen.getByRole("button", { name: "Cancel" });
     fireEvent(
       cancelButton,
       new MouseEvent("click", {

--- a/src/widgets/visit/new-visit.component.tsx
+++ b/src/widgets/visit/new-visit.component.tsx
@@ -1,21 +1,21 @@
 import React, { useEffect } from "react";
-import { getCurrentPatientUuid } from "@openmrs/esm-api";
+import { useTranslation } from "react-i18next";
 import dayjs from "dayjs";
+import { isEmpty } from "lodash-es";
+import { getCurrentPatientUuid } from "@openmrs/esm-api";
+import { FetchResponse } from "@openmrs/esm-api/dist/openmrs-fetch";
+import SummaryCard from "../../ui-components/cards/summary-card.component";
+import LocationSelect from "../location/location-select.component";
+import VisitTypeSelect from "./visit-type-select.component";
 import {
   NewVisitPayload,
   saveVisit,
   UpdateVisitPayload,
   updateVisit
 } from "./visit.resource";
-import { FetchResponse } from "@openmrs/esm-api/dist/openmrs-fetch";
-import LocationSelect from "../location/location-select.component";
-import VisitTypeSelect from "./visit-type-select.component";
-import SummaryCard from "../../ui-components/cards/summary-card.component";
-import styles from "./new-visit.css";
 import useSessionUser from "../../utils/use-session-user";
 import { getStartedVisit, visitMode, visitStatus } from "./visit-utils";
-import { isEmpty } from "lodash-es";
-import { Trans, useTranslation } from "react-i18next";
+import styles from "./new-visit.css";
 
 export default function NewVisit(props: NewVisitProps) {
   const currentUser = useSessionUser();
@@ -35,7 +35,7 @@ export default function NewVisit(props: NewVisitProps) {
   const [visitUuid, setVisitUuid] = React.useState<string>();
 
   if (!locationUuid && currentUser?.sessionLocation?.uuid) {
-    //init with session location
+    // init with session location
     setLocationUuid(currentUser?.sessionLocation?.uuid);
   }
 
@@ -61,7 +61,7 @@ export default function NewVisit(props: NewVisitProps) {
         props.closeComponent();
       },
       error => {
-        console.error("error", error);
+        console.error("Error saving visit: ", error);
       }
     );
   };
@@ -82,7 +82,7 @@ export default function NewVisit(props: NewVisitProps) {
     const ac = new AbortController();
     updateVisit(visitUuid, updateVisitPayload, ac).subscribe(({ data }) => {
       getStartedVisit.next({
-        mode: visitMode.EDITVISI,
+        mode: visitMode.EDITVISIT,
         visitData: data,
         status: visitStatus.ONGOING
       });
@@ -150,9 +150,11 @@ export default function NewVisit(props: NewVisitProps) {
   }, [props.viewMode]);
 
   const newVisitView = () => {
-    const headerText = t("Start new visit", "Start new visit");
     return (
-      <SummaryCard name={headerText} styles={{ margin: 0 }}>
+      <SummaryCard
+        name={t("startNewVisit", "Start new visit")}
+        styles={{ margin: 0 }}
+      >
         <div className={styles.newVisitContainer}>
           <div
             className={`${styles.newVisitInputContainer} ${styles.flexColumn}`}
@@ -164,46 +166,59 @@ export default function NewVisit(props: NewVisitProps) {
               onVisitTypeChanged={visitType =>
                 onVisitTypeChanged(visitType.uuid)
               }
-              id={"visitType"}
+              id="visitType"
               visitTypeUuid={visitTypeUuid}
             />
           </div>
           <div
-            className={`${styles.newVisitInputContainer} ${styles.flexColumn}`}
+            style={{
+              display: "flex",
+              flexFlow: "row wrap",
+              justifyContent: "space-between"
+            }}
           >
-            <label htmlFor="startDate">
-              <Trans i18nKey="startDateTime">Start date/time</Trans>
-            </label>
             <div
-              className={`omrs-datepicker ${styles.flexRow}`}
-              style={{ display: "flex", padding: "0rem 0.25rem" }}
+              className={`${styles.newVisitInputContainer}  ${styles.flexColumn}`}
+              style={{ width: "50%" }}
             >
-              <input
-                type="date"
-                name="startDate"
-                id="startDate"
-                data-testid="date-select"
-                defaultValue={visitStartDate}
-                onChange={onStartDateChanged}
-                style={{ flex: 1, marginRight: "0.625rem" }}
-              />
-              <input
-                type="time"
-                name="startTime"
-                id="startTime"
-                data-testid="time-select"
-                defaultValue={visitStartTime}
-                onChange={onStartTimeChanged}
-                style={{ flex: 1, marginLeft: "0.625rem" }}
-              />
+              <label htmlFor="startDate">{t("startDate", "Start date")}</label>
+              <div className="omrs-datepicker">
+                <input
+                  type="date"
+                  name="startDate"
+                  id="startDate"
+                  defaultValue={visitStartDate}
+                  max={dayjs(new Date().toUTCString()).format("YYYY-MM-DD")}
+                  onChange={onStartDateChanged}
+                />
+                <svg className="omrs-icon" role="img">
+                  <use xlinkHref="#omrs-icon-calendar"></use>
+                </svg>
+              </div>
+            </div>
+            <div
+              className={`${styles.newVisitInputContainer}  ${styles.flexColumn}`}
+              style={{ width: "50%" }}
+            >
+              <label htmlFor="startTime">{t("startTime", "Start time")}</label>
+              <div className="omrs-datepicker">
+                <input
+                  type="time"
+                  name="startTime"
+                  id="startTime"
+                  defaultValue={visitStartTime}
+                  onChange={onStartTimeChanged}
+                />
+                <svg className="omrs-icon" role="img">
+                  <use xlinkHref="#omrs-icon-access-time"></use>
+                </svg>
+              </div>
             </div>
           </div>
           <div
             className={`${styles.newVisitInputContainer} ${styles.flexColumn}`}
           >
-            <label htmlFor="location">
-              <Trans i18nKey="location">Location</Trans>
-            </label>
+            <label htmlFor="location">{t("location", "Location")}</label>
             <LocationSelect
               currentLocationUuid={locationUuid}
               onLocationChanged={location => onLocationChanged(location.uuid)}
@@ -218,13 +233,13 @@ export default function NewVisit(props: NewVisitProps) {
               className={`omrs-btn omrs-outlined-neutral`}
               onClick={() => props.onCanceled()}
             >
-              <Trans i18nKey="cancel">Cancel</Trans>
+              {t("cancel", "Cancel")}
             </button>
             <button
               className={`omrs-btn omrs-filled-action`}
               onClick={() => startVisit()}
             >
-              <Trans i18nKey="start">Start</Trans>
+              {t("start", "Start")}
             </button>
           </div>
         </div>
@@ -233,7 +248,7 @@ export default function NewVisit(props: NewVisitProps) {
   };
 
   const editVisitView = () => {
-    const headerText = t("edit visit", "Edit Visit");
+    const headerText = t("editVisit", "Edit Visit");
     return (
       <SummaryCard name={headerText} styles={{ margin: 0 }}>
         <div className={styles.newVisitContainer}>
@@ -252,63 +267,94 @@ export default function NewVisit(props: NewVisitProps) {
             />
           </div>
           <div
-            className={`${styles.newVisitInputContainer} ${styles.flexColumn}`}
+            style={{
+              display: "flex",
+              flexFlow: "row wrap",
+              justifyContent: "space-between"
+            }}
           >
-            <label htmlFor="startDate">
-              <Trans i18nKey="startDateTime">Start date/time</Trans>
-            </label>
             <div
-              className={`omrs-datepicker ${styles.flexRow}`}
-              style={{ display: "flex", padding: "0rem 0.25rem" }}
+              className={`${styles.newVisitInputContainer}  ${styles.flexColumn}`}
+              style={{ width: "50%" }}
             >
-              <input
-                type="date"
-                name="startDate"
-                id="startDate"
-                data-testid="date-select"
-                value={visitStartDate}
-                onChange={onStartDateChanged}
-                style={{ flex: 1, marginRight: "0.625rem" }}
-              />
-              <input
-                type="time"
-                name="startTime"
-                id="startTime"
-                data-testid="time-select"
-                value={visitStartTime}
-                onChange={onStartTimeChanged}
-                style={{ flex: 1, marginLeft: "0.625rem" }}
-              />
+              <label htmlFor="startDate">{t("startDate", "Start date")}</label>
+              <div className="omrs-datepicker">
+                <input
+                  type="date"
+                  name="startDate"
+                  id="startDate"
+                  data-testid="date-select"
+                  value={visitStartDate}
+                  onChange={onStartDateChanged}
+                />
+                <svg className="omrs-icon" role="img">
+                  <use xlinkHref="#omrs-icon-calendar"></use>
+                </svg>
+              </div>
+            </div>
+            <div
+              className={`${styles.newVisitInputContainer}  ${styles.flexColumn}`}
+              style={{ width: "50%" }}
+            >
+              <label htmlFor="startTime">{t("startTime", "Start time")}</label>
+              <div className="omrs-datepicker">
+                <input
+                  type="time"
+                  name="startTime"
+                  id="startTime"
+                  defaultValue={visitStartTime}
+                  onChange={onStartTimeChanged}
+                />
+                <svg className="omrs-icon" role="img">
+                  <use xlinkHref="#omrs-icon-access-time"></use>
+                </svg>
+              </div>
             </div>
           </div>
           <div
-            className={`${styles.newVisitInputContainer} ${styles.flexColumn}`}
+            style={{
+              display: "flex",
+              flexFlow: "row wrap",
+              justifyContent: "space-between"
+            }}
           >
-            <label htmlFor="endDate">
-              <Trans i18nKey="endDateTime">End date/time</Trans>
-            </label>
             <div
-              className={`omrs-datepicker ${styles.flexRow}`}
-              style={{ display: "flex", padding: "0rem 0.25rem" }}
+              className={`${styles.newVisitInputContainer}  ${styles.flexColumn}`}
+              style={{ width: "50%" }}
             >
-              <input
-                type="date"
-                name="endDate"
-                id="endDate"
-                data-testid="date-select-end-date"
-                value={visitEndDate}
-                onChange={onVisitStopDateChanged}
-                style={{ flex: 1, marginRight: "0.625rem" }}
-              />
-              <input
-                type="time"
-                name="endTime"
-                id="endTime"
-                data-testid="time-select-end-time"
-                value={visitEndTime}
-                onChange={onVisitStopTimeChanged}
-                style={{ flex: 1, marginLeft: "0.625rem" }}
-              />
+              <label htmlFor="endDate">{t("endDate", "End date")}</label>
+              <div className="omrs-datepicker">
+                <input
+                  type="date"
+                  name="endDate"
+                  id="endDate"
+                  data-testid="date-select-end-date"
+                  value={visitEndDate}
+                  onChange={onVisitStopDateChanged}
+                />
+                <svg className="omrs-icon" role="img">
+                  <use xlinkHref="#omrs-icon-calendar"></use>
+                </svg>
+              </div>
+            </div>
+            <div
+              className={`${styles.newVisitInputContainer}  ${styles.flexColumn}`}
+              style={{ width: "50%" }}
+            >
+              <label htmlFor="endTime">{t("endTime", "End time")}</label>
+              <div className="omrs-datepicker">
+                <input
+                  type="time"
+                  name="endTime"
+                  id="endTime"
+                  data-testid="time-select-end-time"
+                  value={visitEndTime}
+                  onChange={onVisitStopTimeChanged}
+                />
+                <svg className="omrs-icon" role="img">
+                  <use xlinkHref="#omrs-icon-access-time"></use>
+                </svg>
+              </div>
             </div>
           </div>
           <div
@@ -332,13 +378,13 @@ export default function NewVisit(props: NewVisitProps) {
                 getStartedVisit.next(null);
               }}
             >
-              <Trans i18nKey="cancel">Cancel</Trans>
+              {t("cancel", "Cancel")}
             </button>
             <button
               className={`omrs-btn omrs-filled-action`}
               onClick={handleUpdateVisit}
             >
-              <Trans i18nKey="editVisit">Edit visit</Trans>
+              {t("editVisit", "Edit visit")}
             </button>
           </div>
         </div>

--- a/src/widgets/visit/new-visit.css
+++ b/src/widgets/visit/new-visit.css
@@ -2,6 +2,7 @@
   display: flex;
   position: relative;
   margin: 0.325rem;
+  padding: 0.25rem 0.625rem;
   flex-direction: column;
   justify-content: flex-start;
 }
@@ -9,13 +10,13 @@
 .newVisitInputContainer {
   display: flex;
   align-items: center;
-  margin-top: 0.25rem;
+  margin: 0.625rem 0;
 }
 
 .newVisitContainer label {
   color: var(--omrs-color-ink-medium-contrast);
-  padding: 0.25rem 0.625rem;
   font-weight: 500;
+  margin-bottom: 0.375rem;
 }
 
 .newVisitContainer select {

--- a/src/widgets/visit/visit-button.component.tsx
+++ b/src/widgets/visit/visit-button.component.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import VisitDashboard from "./visit-dashboard.component";
 import styles from "./visit-button.css";
 import {
@@ -21,13 +21,8 @@ import { FetchResponse } from "@openmrs/esm-api/dist/openmrs-fetch";
 
 export default function VisitButton(props: VisitButtonProps) {
   const [selectedVisit, setSelectedVisit] = useState(null);
-  const [visitStarted, setVisitStarted] = useState<boolean>();
-  const [
-    isLoadingPatient,
-    patient,
-    patientUuid,
-    patientErr
-  ] = useCurrentPatient();
+  const [, setVisitStarted] = useState<boolean>();
+  const [, , patientUuid] = useCurrentPatient();
 
   useEffect(() => {
     const sub = getStartedVisit.subscribe((visit: visitItem) => {
@@ -59,23 +54,25 @@ export default function VisitButton(props: VisitButtonProps) {
   }, [patientUuid]);
 
   const StartVisitButton: React.FC = () => {
+    const { t } = useTranslation();
     return (
       <div>
         <button
           className={styles.startVisitButton}
           data-testid="start-visit"
           onClick={() => {
-            openVisitDashboard();
+            openVisitDashboard(`${t("visitDashboard", "Visit Dashboard")}`);
             setVisitStarted(true);
           }}
         >
-          <Trans i18nKey="startVisit">Start visit</Trans>
+          {t("startVisit", "Start visit")}
         </button>
       </div>
     );
   };
 
   const EditVisitButton: React.FC = () => {
+    const { t } = useTranslation();
     return (
       selectedVisit && (
         <div className={styles.editContainer}>
@@ -97,7 +94,7 @@ export default function VisitButton(props: VisitButtonProps) {
                 });
               }}
             >
-              <Trans i18nKey="end">End</Trans>
+              {t("end", "End")}
             </button>
           )}
           <svg
@@ -136,7 +133,7 @@ export const StartVisitConfirmation: React.FC = () => {
     <div className={styles.visitPromptContainer}>
       <h2>
         {t(
-          "START_VISIT_CONFIRM_LABEL",
+          "startVisitPrompt",
           "No active visit is selected. Do you want to start a visit?"
         )}
       </h2>
@@ -144,17 +141,17 @@ export const StartVisitConfirmation: React.FC = () => {
         <button
           className={`omrs-btn omrs-outlined-action`}
           onClick={() => {
-            openVisitDashboard();
+            openVisitDashboard(`${t("visitDashboard", "Visit Dashboard")}`);
             hideModal();
           }}
         >
-          <Trans i18nKey="yes">Yes</Trans>
+          {t("yes", "Yes")}
         </button>
         <button
           className={`omrs-btn omrs-outlined-neutral`}
           onClick={() => hideModal()}
         >
-          <Trans i18nKey="no">No</Trans>
+          {t("no", "No")}
         </button>
       </div>
     </div>
@@ -164,12 +161,15 @@ export const StartVisitConfirmation: React.FC = () => {
 const CloseActiveVisitConfirmation: React.FC<EndVisitProps> = ({
   currentVisit
 }) => {
+  const { t } = useTranslation();
   return (
     <div className={styles.visitPromptContainer}>
-      <h2>Are you sure to close this visit</h2>
+      <h2>{t("endVisitPrompt", "Are you sure you want to end this visit?")}</h2>
       <p>
-        Visit Type : {currentVisit.visitData.visitType.display} Location:{" "}
-        {currentVisit.visitData?.location?.display} Start Date:{" "}
+        {t("visitType", "Visit Type")}:{" "}
+        {currentVisit.visitData.visitType.display} {t("location", "Location")}:{" "}
+        {currentVisit.visitData?.location?.display}{" "}
+        {t("startDate", "Start Date")}:{" "}
         {dayjs(currentVisit.visitData.startDatetime).format("DD-MMM-YYYY")}
       </p>
       <div className={styles.visitPromptButtonsContainer}>
@@ -180,13 +180,13 @@ const CloseActiveVisitConfirmation: React.FC<EndVisitProps> = ({
             hideModal();
           }}
         >
-          Yes
+          {t("yes", "Yes")}
         </button>
         <button
           className={`omrs-btn omrs-outlined-neutral`}
           onClick={() => hideModal()}
         >
-          No
+          {t("no", "No")}
         </button>
       </div>
     </div>
@@ -198,16 +198,15 @@ interface EndVisitProps {
 }
 
 export const EndVisit: React.FC<EndVisitProps> = ({ currentVisit }) => {
+  const { t } = useTranslation();
   return (
     <div className={styles.visitPromptContainer}>
-      <h2>
-        <Trans i18nKey="endVisitPrompt">
-          Are you sure you wish to end this visit?
-        </Trans>
-      </h2>
+      <h2>{t("endVisitPrompt", "Are you sure you wish to end this visit?")}</h2>
       <p>
-        Visit Type : {currentVisit.visitData.visitType.display} Location :{" "}
-        {currentVisit.visitData.location.display} Start Date :{" "}
+        {t("visitType", "Visit Type")}:{" "}
+        {currentVisit.visitData.visitType.display} {t("location", "Location")}:{" "}
+        {currentVisit.visitData?.location?.display}{" "}
+        {t("startDate", "Start Date")}:{" "}
         {dayjs(currentVisit.visitData.startDatetime).format("DD-MMM-YYYY")}
       </p>
       <div className={styles.visitPromptButtonsContainer}>
@@ -218,23 +217,23 @@ export const EndVisit: React.FC<EndVisitProps> = ({ currentVisit }) => {
             hideModal();
           }}
         >
-          Yes
+          {t("yes", "Yes")}
         </button>
         <button
           className={`omrs-btn omrs-outlined-neutral`}
           onClick={() => hideModal()}
         >
-          No
+          {t("no", "No")}
         </button>
       </div>
     </div>
   );
 };
 
-const openVisitDashboard = () => {
+const openVisitDashboard = (componentName: string): void => {
   newWorkspaceItem({
     component: VisitDashboard,
-    name: "Visit Dashboard",
+    name: componentName,
     props: {},
     inProgress: false,
     validations: (workspaceTabs: Array<{ component: React.FC }>) =>

--- a/src/widgets/visit/visit-utils.tsx
+++ b/src/widgets/visit/visit-utils.tsx
@@ -24,9 +24,10 @@ export type visitItem = {
 
 export enum visitMode {
   NEWVISIT = "startVisit",
-  EDITVISI = "editVisit",
+  EDITVISIT = "editVisit",
   LOADING = "loadingVisit"
 }
+
 export enum visitStatus {
   NOTSTARTED = "notStarted",
   ONGOING = "ongoing"


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-219

- Adds translation keys to the components that make up the visits widget as well as minimal improvements to styling and tests.
- Separates out the `Start date` and `Start time` input labels so they operate independent of each other. A positive corollary of this is that we no longer need to use data-testids to query DOM elements when testing which is not ideal anyway. This has potentially unearthed a subtle bug with the way the Visit stop time is determined when editing a visit. I will investigate further and potentially fix this in a subsequent PR.

<img width="665" alt="Screenshot 2020-09-23 at 20 13 56" src="https://user-images.githubusercontent.com/8509731/94046439-5c825f80-fdd9-11ea-8fa2-0fc5dd4f56b7.png">
<img width="751" alt="Screenshot 2020-09-23 at 20 06 44" src="https://user-images.githubusercontent.com/8509731/94046491-699f4e80-fdd9-11ea-86fc-5e3a070b8632.png">
<img width="808" alt="Screenshot 2020-09-23 at 20 07 21" src="https://user-images.githubusercontent.com/8509731/94046505-6c9a3f00-fdd9-11ea-9e68-e5464e7b2899.png">
