### PR TITLE
Fix Travis status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/openmrs/openmrs-esm-patient-chart-widgets.svg?branch=master)](https://travis-ci.org/openmrs/openmrs-esm-patient-chart-widgets)
+[![Build Status](https://travis-ci.com/openmrs/openmrs-esm-patient-chart-widgets.svg?branch=master)](https://travis-ci.com/openmrs/openmrs-esm-patient-chart-widgets)
 
 # OpenMRS ESM Patient Chart Widgets
 


### PR DESCRIPTION
Points status badge link to new Travis CI URL.

Before:
<img width="118" alt="Screenshot 2020-10-26 at 20 22 50" src="https://user-images.githubusercontent.com/8509731/97206004-3e898f80-17c9-11eb-957c-e3f81f8c324a.png">

After:
<img width="115" alt="Screenshot 2020-10-26 at 20 24 11" src="https://user-images.githubusercontent.com/8509731/97206017-41848000-17c9-11eb-824b-573021b60d2d.png">
