### PR TITLE
Modify relationships request query params to use custom representation

### DIFF
--- a/src/widgets/contact-details/contact-details.component.tsx
+++ b/src/widgets/contact-details/contact-details.component.tsx
@@ -60,16 +60,16 @@ const Relationships: React.FC<{ patientId: string }> = ({ patientId }) => {
       if (patientId === r.personA.uuid) {
         relationshipsData.push({
           uuid: r.uuid,
-          display: r.personB.display,
-          relativeAge: r.personB.age,
+          display: r.personB.person.display,
+          relativeAge: r.personB.person.age,
           relativeUuid: r.personB.uuid,
           relationshipType: r.relationshipType.bIsToA
         });
       } else {
         relationshipsData.push({
           uuid: r.uuid,
-          display: r.personA.display,
-          relativeAge: r.personA.age,
+          display: r.personA.person.display,
+          relativeAge: r.personA.person.age,
           relativeUuid: r.personA.uuid,
           relationshipType: r.relationshipType.aIsToB
         });

--- a/src/widgets/contact-details/contact-details.test.tsx
+++ b/src/widgets/contact-details/contact-details.test.tsx
@@ -36,7 +36,10 @@ it("displays the patient's contact details", async () => {
         results: [
           {
             uuid: 2222,
-            personA: { display: "Amanda", age: 30, uuid: 2222 },
+            personA: {
+              person: { display: "Amanda Testerson", age: 30 },
+              uuid: 2222
+            },
             relationshipType: { aIsToB: "Cousin" }
           }
         ]
@@ -50,5 +53,6 @@ it("displays the patient's contact details", async () => {
   expect(screen.getByText("Address")).toBeInTheDocument();
   expect(screen.getByText("Contact Details")).toBeInTheDocument();
   expect(screen.getByText("Relationships")).toBeInTheDocument();
-  expect(screen.getByText(/cousin/i)).toBeInTheDocument();
+  expect(screen.getByText("Amanda Testerson")).toBeInTheDocument();
+  expect(screen.getByText(/Cousin/i)).toBeInTheDocument();
 });

--- a/src/widgets/contact-details/relationships.resource.tsx
+++ b/src/widgets/contact-details/relationships.resource.tsx
@@ -1,8 +1,14 @@
 import { openmrsFetch } from "@openmrs/esm-api";
 
+const customRepresentation =
+  "custom:(display,uuid," +
+  "personA:(uuid,display,person:(age,display))," +
+  "personB:(uuid,display,person:(age,display))," +
+  "relationshipType:(uuid,display,description,aIsToB,bIsToA))";
+
 export function fetchPatientRelationships(patientIdentifier: string) {
   return openmrsFetch<{ results: Relationship[] }>(
-    `/ws/rest/v1/relationship?v=full&person=${patientIdentifier}`
+    `/ws/rest/v1/relationship?v=${customRepresentation}&person=${patientIdentifier}`
   );
 }
 
@@ -10,14 +16,18 @@ export type Relationship = {
   display: string;
   uuid: number;
   personA: {
-    age: number;
-    display: string;
     uuid: string;
+    person: {
+      age: number;
+      display: string;
+    };
   };
   personB: {
-    age: number;
-    display: string;
     uuid: string;
+    person: {
+      age: number;
+      display: string;
+    };
   };
   relationshipType: {
     uuid: string;


### PR DESCRIPTION
Switch from `full` to custom representation in request URL query params.