### PR TITLE
Contact details button should toggle caret types

### DIFF
--- a/src/widgets/banner/patient-banner.component.tsx
+++ b/src/widgets/banner/patient-banner.component.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import dayjs from "dayjs";
 import { Button } from "carbon-components-react";
-import { CaretDown16 } from "@carbon/icons-react";
+import { CaretDown16, CaretUp16 } from "@carbon/icons-react";
 import capitalize from "lodash-es/capitalize";
 
 import { useCurrentPatient } from "@openmrs/esm-react-utils";
@@ -48,7 +48,7 @@ export default function PatientBanner() {
                 </span>
                 <Button
                   kind="ghost"
-                  renderIcon={CaretDown16}
+                  renderIcon={showContactDetails ? CaretUp16 : CaretDown16}
                   iconDescription="Toggle contact details"
                   onClick={toggleContactDetails}
                 >


### PR DESCRIPTION
Hat tip to Ciaran for spotting this - clicking the button should toggle between the caret pointing up and down as well.

![contact-details-button-caret](https://user-images.githubusercontent.com/8509731/100744336-b82b2380-33ee-11eb-82d4-92b4b13b858b.gif)
