### PR TITLE
Tighten up margins of elements in the patient banner

### DIFF
--- a/src/widgets/banner/patient-banner.scss
+++ b/src/widgets/banner/patient-banner.scss
@@ -36,6 +36,7 @@
   flex-direction: row;
   justify-content: space-between;
   align-items: baseline;
+  margin-top: -0.125rem;
 }
 
 .identifiers {


### PR DESCRIPTION
Following on from this feedback from Ciaran: 

![Screenshot 2020-12-07 at 09 40 38](https://user-images.githubusercontent.com/8509731/101317848-59432f80-3870-11eb-93ed-b2ead8cb68dc.png)

Before:

![Screenshot 2020-12-07 at 09 39 55](https://user-images.githubusercontent.com/8509731/101317910-74ae3a80-3870-11eb-9203-33dad9500848.png)

After:

![copy without baseline](https://user-images.githubusercontent.com/8509731/101318032-b50db880-3870-11eb-8e79-53b50277f4a8.png)

Is the use of negative margins here egregious?

