### PR TITLE
Fix subtle bug in allergies resource

### DIFF
--- a/src/widgets/allergies/allergy-intolerance.resource.tsx
+++ b/src/widgets/allergies/allergy-intolerance.resource.tsx
@@ -13,7 +13,7 @@ export function performPatientAllergySearch(patientIdentifier: string) {
     `${fhirBaseUrl}/AllergyIntolerance?patient.identifier=${patientIdentifier}`
   ).pipe(
     map(({ data }) => data["entry"]),
-    map(entries => entries?.map(entry => entry?.resource)),
+    map(entries => entries?.map(entry => entry?.resource) ?? []),
     map(data => formatAllergies(data)),
     map(data => data.sort((a, b) => (b.lastUpdated > a.lastUpdated ? 1 : -1)))
   );

--- a/src/widgets/biometrics/biometrics-overview.component.test.tsx
+++ b/src/widgets/biometrics/biometrics-overview.component.test.tsx
@@ -45,7 +45,6 @@ describe("<Biometric/>", () => {
   it("should display empty biometrics", () => {
     mockGetPatientBiometric.mockReturnValue(of([]));
     const wrapper = render(<BiometricOverview />);
-    screen.debug(wrapper.container);
     expect(
       screen.getByText("There are no biometrics to display for this patient")
     ).toBeInTheDocument();


### PR DESCRIPTION
This PR

- Fixes a bug in the `performPatientAllergySearch` function when an empty result is returned from the API request for allergies.
- Also removes a superfluous `console.log` from a test file.