### PR TITLE
MF-398: Onset date should not be required

### DIFF
--- a/src/widgets/conditions/conditions-form.component.tsx
+++ b/src/widgets/conditions/conditions-form.component.tsx
@@ -129,7 +129,6 @@ export function ConditionsForm(props: ConditionsFormProps) {
                     id="onsetDate"
                     type="date"
                     name="onsetDate"
-                    required
                     onChange={event => setOnsetDateTime(event.target.value)}
                   />
                   <svg className="omrs-icon" role="img">


### PR DESCRIPTION
[Ticket](https://issues.openmrs.org/browse/MF-398)

`Onset date` should be an optional field when recording a condition.