### PR TITLE
Add ability to launch vitals form

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,8 +52,8 @@ function setupOpenMRS() {
         )
       },
       {
-        id: "patient-vital-header-ext",
-        slot: "patient-vital-header-status-bar",
+        id: "patient-vital-status-ext",
+        slot: "patient-vital-status",
         load: getAsyncLifecycle(
           () =>
             import(
@@ -66,8 +66,8 @@ function setupOpenMRS() {
         )
       },
       {
-        id: "patient-banner-ext",
-        slot: "patient-banner",
+        id: "patient-chart-header-ext",
+        slot: "patient-chart-header",
         load: getAsyncLifecycle(
           () => import("./widgets/banner/patient-banner.component"),
           {

--- a/src/widgets/vitals/vitals-header/vital-header-title.component.tsx
+++ b/src/widgets/vitals/vitals-header/vital-header-title.component.tsx
@@ -11,6 +11,8 @@ import { Button } from "carbon-components-react";
 import { PatientVitals } from "../vitals-biometrics.resource";
 import { isEmpty } from "lodash-es";
 import { useTranslation } from "react-i18next";
+import { useCurrentPatient } from "@openmrs/esm-react-utils";
+import { switchTo } from "@openmrs/esm-extensions";
 dayjs.extend(isToday);
 
 interface VitalsHeaderStateTitleProps {
@@ -27,6 +29,13 @@ const VitalsHeaderStateTitle: React.FC<VitalsHeaderStateTitleProps> = ({
   showDetails
 }) => {
   const { t } = useTranslation();
+  const [isLoadingPatient, , patientUuid] = useCurrentPatient();
+  const launchVitalsBiometricsForm = () => {
+    const url = `/patient/${patientUuid}/vitalsbiometrics/form`;
+    switchTo("workspace", url, {
+      title: t("recordVitalsAndBiometrics", "Record Vitals and Biometrics")
+    });
+  };
   return (
     <>
       {!isEmpty(vitals) ? (
@@ -50,7 +59,12 @@ const VitalsHeaderStateTitle: React.FC<VitalsHeaderStateTitleProps> = ({
             </span>
           </span>
           <div className={styles.alignCenter}>
-            <Button className={styles.buttonText} kind="ghost" size="small">
+            <Button
+              className={styles.buttonText}
+              kind="ghost"
+              size="small"
+              onClick={launchVitalsBiometricsForm}
+            >
               {t("recordVitals", "Record Vitals")}
             </Button>
             {showDetails ? (


### PR DESCRIPTION
### What does this PR do?

1. It adds ability to launch `vitals-biometrics form`
2. Rename the vitals header and patient banner  extensions to `patient-vitals-status` and `patient-chart-header`
3. [MF-384](https://github.com/openmrs/openmrs-esm-patient-chart/pull/192)