### PR TITLE
Align tile states text content explicitly

### DIFF
--- a/src/ui-components/empty-state/empty-state.component.tsx
+++ b/src/ui-components/empty-state/empty-state.component.tsx
@@ -10,7 +10,7 @@ const EmptyState: React.FC<EmptyStateProps> = props => {
   const { t } = useTranslation();
 
   return (
-    <Tile light>
+    <Tile light className={styles.tile}>
       <h1 className={styles.heading}>{props.headerTitle}</h1>
       <EmptyDataIllustration />
       <p className={styles.content}>

--- a/src/ui-components/empty-state/empty-state.scss
+++ b/src/ui-components/empty-state/empty-state.scss
@@ -18,3 +18,7 @@
   @include carbon--type-style("productive-heading-03");
   color: $text-02;
 }
+
+.tile {
+  text-align: center;
+}

--- a/src/ui-components/error-state/error-state.component.tsx
+++ b/src/ui-components/error-state/error-state.component.tsx
@@ -9,7 +9,7 @@ const EmptyState: React.FC<ErrorStateProps> = ({ error, headerTitle }) => {
   const { t } = useTranslation();
 
   return (
-    <Tile light>
+    <Tile light className={styles.tile}>
       <h1 className={styles.heading}>{headerTitle}</h1>
       <p className={styles.errorMessage}>
         {t("error", "Error")} {`${error.response.status}: `}

--- a/src/ui-components/error-state/error-state.scss
+++ b/src/ui-components/error-state/error-state.scss
@@ -20,3 +20,7 @@
   @include carbon--type-style("productive-heading-03");
   color: $text-02;
 }
+
+.tile {
+  text-align: center;
+}


### PR DESCRIPTION
![Screenshot 2021-02-02 at 14 08 03](https://user-images.githubusercontent.com/8509731/106592263-58710600-6560-11eb-8567-f80628b29df7.png)

![Screenshot 2021-02-02 at 14 07 56](https://user-images.githubusercontent.com/8509731/106592292-62930480-6560-11eb-9eea-9ec45638b185.png)

The text inside the empty and error state tiles is mistakenly receiving horizontal alignment from a class declared in the `patient chart` app. This commit adds explicit horizontal alignment to the tiles instead.