### PR TITLE
Small touches to the vitals header

### DIFF
--- a/src/root.scss
+++ b/src/root.scss
@@ -9,6 +9,7 @@ $ui-03: #e0e0e0;
 $ui-05: #161616;
 $ui-background: #ffffff;
 $color-gray-70: #525252;
+$color-blue-60-2: #0f62fe;
 $color-yellow-50: #feecae;
 $inverse-support-03: #f1c21b;
 $warning-background: #fff8e1;

--- a/src/widgets/vitals/vitals-header/vital-header-state.component.scss
+++ b/src/widgets/vitals/vitals-header/vital-header-state.component.scss
@@ -7,6 +7,7 @@
 
 .warningBackground {
   background-color: $warning-background;
+  border-left: 0.19rem solid $inverse-support-03;
   border-bottom: $spacing-01 solid $color-yellow-50;
 }
 

--- a/src/widgets/vitals/vitals-header/vital-header-title.component.scss
+++ b/src/widgets/vitals/vitals-header/vital-header-title.component.scss
@@ -26,3 +26,7 @@
 .buttonText {
   @extend .bodyShort01;
 }
+
+.expandButton {
+  color: $color-blue-60-2;
+}

--- a/src/widgets/vitals/vitals-header/vital-header-title.component.tsx
+++ b/src/widgets/vitals/vitals-header/vital-header-title.component.tsx
@@ -68,9 +68,17 @@ const VitalsHeaderStateTitle: React.FC<VitalsHeaderStateTitleProps> = ({
               {t("recordVitals", "Record Vitals")}
             </Button>
             {showDetails ? (
-              <ChevronUp20 title={"ChevronUp"} onClick={toggleView} />
+              <ChevronUp20
+                className={styles.expandButton}
+                title={"ChevronUp"}
+                onClick={toggleView}
+              />
             ) : (
-              <ChevronDown20 title={"ChevronDown"} onClick={toggleView} />
+              <ChevronDown20
+                className={styles.expandButton}
+                title={"ChevronDown"}
+                onClick={toggleView}
+              />
             )}
           </div>
         </div>


### PR DESCRIPTION
- Add a 3px yellow (#f1c21b) border to the left of the vitals header when in the warning state.
- Change the color of the `expand` chevron to blue (#0f62fe).

Before:

![Screenshot 2021-02-02 at 15 28 20](https://user-images.githubusercontent.com/8509731/106600337-52345700-656b-11eb-9513-d758291b5215.png)

After:

![Screenshot 2021-02-02 at 15 26 40](https://user-images.githubusercontent.com/8509731/106600252-32049800-656b-11eb-8814-2b319842e8b9.png)
