### PR TITLE
More changes to the vitals header

### DIFF
--- a/src/root.scss
+++ b/src/root.scss
@@ -49,6 +49,7 @@ $interactive-01: #0f62fe;
 .helperText01 {
   @include carbon--type-style("helper-text-01");
 }
+
 .bodyShort02 {
   @include carbon--type-style("body-short-02");
 }
@@ -63,4 +64,12 @@ $interactive-01: #0f62fe;
 
 .label01 {
   @include carbon--type-style("label-01");
+}
+
+.text01 {
+  color: $text-01;
+}
+
+.text02 {
+  color: $text-02;
 }

--- a/src/widgets/vitals/vitals-header/vital-header-details.component.tsx
+++ b/src/widgets/vitals/vitals-header/vital-header-details.component.tsx
@@ -14,7 +14,7 @@ const VitalHeaderStateDetails: React.FC<VitalHeaderStateDetailsProps> = ({
 }) => {
   return (
     <div className={styles.vitalsHeaderStateDetailsContainer}>
-      <label className={styles.label01}>{unitName}</label>
+      <label className={`${styles.label01} ${styles.text02}`}>{unitName}</label>
       <label>
         <span className={styles.bodyShort02}>{value || "-"} </span>
         <span className={styles.vitalsDetailsBodyShort01}>

--- a/src/widgets/vitals/vitals-header/vital-header-state.component.test.tsx
+++ b/src/widgets/vitals/vitals-header/vital-header-state.component.test.tsx
@@ -49,7 +49,7 @@ describe("<VitalHeader/>", () => {
     expect(screen.getByText(/Temp/i)).toBeInTheDocument();
     expect(screen.getByText(/Heart Rate/i)).toBeInTheDocument();
     expect(screen.getByText(/SPO2/i)).toBeInTheDocument();
-    expect(screen.getByText(/R.Rate/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/R. Rate/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Height/i)).toBeInTheDocument();
     expect(screen.getByText(/BMI/i)).toBeInTheDocument();
     expect(screen.getByText(/Weight/i)).toBeInTheDocument();

--- a/src/widgets/vitals/vitals-header/vital-header-state.component.tsx
+++ b/src/widgets/vitals/vitals-header/vital-header-state.component.tsx
@@ -102,8 +102,8 @@ const VitalHeader: React.FC = () => {
               </div>
               <div className={styles.row}>
                 <VitalHeaderStateDetails
-                  unitName={t("respiratoryRate", "R.Rate")}
-                  unitSymbol="/min"
+                  unitName={t("respiratoryRate", "R. Rate")}
+                  unitSymbol="/ min"
                   value={vital.temperature}
                 />
                 <VitalHeaderStateDetails
@@ -113,11 +113,7 @@ const VitalHeader: React.FC = () => {
                 />
                 <VitalHeaderStateDetails
                   unitName={t("bmi", "BMI")}
-                  unitSymbol={
-                    <span>
-                      kg / m<sup className={styles.helperText01}>2</sup>
-                    </span>
-                  }
+                  unitSymbol={<span>kg / m²</span>}
                   value={vital.bmi}
                 />
                 <VitalHeaderStateDetails

--- a/src/widgets/vitals/vitals-header/vital-header-title.component.scss
+++ b/src/widgets/vitals/vitals-header/vital-header-title.component.scss
@@ -1,8 +1,13 @@
 @import "../../../root.scss";
 
-.warningColor {
+.warningIcon {
   fill: $inverse-support-03;
-  margin: 0 $spacing-05 0 0;
+  margin-right: $spacing-05;
+}
+
+.warningIcon [data-icon-path="inner-path"] {
+  fill: black;
+  opacity: 1;
 }
 
 .alignCenter {
@@ -21,6 +26,7 @@
 .vitalName {
   @extend .productiveHeading02;
   margin: 0 $spacing-05 0 0;
+  color: $text-02;
 }
 
 .buttonText {

--- a/src/widgets/vitals/vitals-header/vital-header-title.component.test.tsx
+++ b/src/widgets/vitals/vitals-header/vital-header-title.component.test.tsx
@@ -66,7 +66,7 @@ describe("<VitalsHeaderStateDetails/>", () => {
       />
     );
     expect(
-      await screen.findByText(/have not been recorded for this patient/)
+      await screen.findByText(/No data has been recorded for this patient/i)
     ).toBeInTheDocument();
 
     expect(

--- a/src/widgets/vitals/vitals-header/vital-header-title.component.tsx
+++ b/src/widgets/vitals/vitals-header/vital-header-title.component.tsx
@@ -44,12 +44,12 @@ const VitalsHeaderStateTitle: React.FC<VitalsHeaderStateTitleProps> = ({
             {view === "Warning" && (
               <WarningFilled20
                 title={"WarningFilled"}
-                aria-label="Add"
-                className={styles.warningColor}
+                aria-label="Warning"
+                className={styles.warningIcon}
               />
             )}
             <span className={styles.vitalName}>Vitals & Biometrics</span>
-            <span className={styles.bodyShort01}>
+            <span className={`${styles.bodyShort01} ${styles.text02}`}>
               {t("lastRecorded", "Last Recorded")}:{" "}
               {dayjs(vitals.date).isToday()
                 ? `${t("today", "Today")}, ${dayjs(vitals.date).format(
@@ -87,15 +87,15 @@ const VitalsHeaderStateTitle: React.FC<VitalsHeaderStateTitleProps> = ({
           <span className={styles.alignCenter}>
             {view === "Warning" && (
               <WarningFilled20
-                aria-label="Add"
-                className={styles.warningColor}
+                aria-label="Warning"
+                className={styles.warningIcon}
               />
             )}
             <span className={styles.vitalName}>Vitals & Biometrics</span>
             <span className={styles.bodyShort01}>
               {t(
-                "haveNotBeenRecorderForThisPatient",
-                "have not been recorded for this patient"
+                "noDataRecorded",
+                "No data has been recorded for this patient"
               )}
             </span>
           </span>


### PR DESCRIPTION
- Change the fill colour of the inner path of the `WarningFilled` icon (the exclamation mark inside the svg) from white to black.
- Change the colour of the vitals header text from black to `$text-02` (#525252).
- Change vitals header text to `No data has been recorded for this patient` when no vitals and biometrics data exists.
- Add a space to the `R. Rate` label.

All of these changes conform to the [latest designs](https://app.zeplin.io/project/5f7223cfda10f94d67cec6d0/screen/601828f4ee5eb42d08ddd67b) and have Ciaran's approval.

Collapsed:
![Screenshot 2021-02-03 at 14 06 51](https://user-images.githubusercontent.com/8509731/106740111-08ab4100-662b-11eb-9637-40cfd7b2697e.png)

Expanded:
![Screenshot 2021-02-03 at 14 07 03](https://user-images.githubusercontent.com/8509731/106740021-f4674400-662a-11eb-890a-c704177cc487.png)

Empty state:
![Screenshot 2021-02-03 at 14 23 05](https://user-images.githubusercontent.com/8509731/106740453-7bb4b780-662b-11eb-848c-01e3a8ecac5c.png)

Finally, this linked PR adds translation strings for the vitals header: https://github.com/openmrs/openmrs-esm-patient-chart/pull/205



