### PR TITLE
Overview widget UI mods

### DIFF
--- a/src/widgets/allergies/allergies-overview.component.tsx
+++ b/src/widgets/allergies/allergies-overview.component.tsx
@@ -86,7 +86,7 @@ const AllergiesOverview: React.FC<AllergiesOverviewProps> = () => {
               iconDescription="Add allergies"
               onClick={launchAllergiesForm}
             >
-              Add
+              {t("add", "Add")}
             </Button>
           </div>
           <TableContainer>

--- a/src/widgets/allergies/allergies-overview.component.tsx
+++ b/src/widgets/allergies/allergies-overview.component.tsx
@@ -90,7 +90,12 @@ const AllergiesOverview: React.FC<AllergiesOverviewProps> = () => {
             </Button>
           </div>
           <TableContainer>
-            <DataTable rows={rows} headers={headers} isSortable={true}>
+            <DataTable
+              rows={rows}
+              headers={headers}
+              isSortable={true}
+              size="short"
+            >
               {({ rows, headers, getHeaderProps, getTableProps }) => (
                 <Table {...getTableProps()}>
                   <TableHead>

--- a/src/widgets/allergies/allergies-overview.component.tsx
+++ b/src/widgets/allergies/allergies-overview.component.tsx
@@ -77,7 +77,9 @@ const AllergiesOverview: React.FC<AllergiesOverviewProps> = () => {
       return (
         <div>
           <div className={styles.allergiesHeader}>
-            <h4>{headerTitle}</h4>
+            <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
+              {headerTitle}
+            </h4>
             <Button
               kind="ghost"
               renderIcon={Add16}

--- a/src/widgets/allergies/allergies-overview.scss
+++ b/src/widgets/allergies/allergies-overview.scss
@@ -4,5 +4,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: $spacing-03;
+  padding: $spacing-04 0 $spacing-04 $spacing-05;
+  background-color: $ui-background;
 }

--- a/src/widgets/appointments/appointments-overview.component.tsx
+++ b/src/widgets/appointments/appointments-overview.component.tsx
@@ -67,7 +67,7 @@ const AppointmentsOverview: React.FC<AppointmentOverviewProps> = () => {
     },
     {
       key: "startDateTime",
-      header: t("date", "Date") // TODO: Update translation keys
+      header: t("date", "Date")
     },
     {
       key: "status",
@@ -98,7 +98,7 @@ const AppointmentsOverview: React.FC<AppointmentOverviewProps> = () => {
               iconDescription="Add appointments"
               onClick={launchAppointmentsForm}
             >
-              Add
+              {t("add", "Add")}
             </Button>
           </div>
           <TableContainer>

--- a/src/widgets/appointments/appointments-overview.component.tsx
+++ b/src/widgets/appointments/appointments-overview.component.tsx
@@ -102,7 +102,12 @@ const AppointmentsOverview: React.FC<AppointmentOverviewProps> = () => {
             </Button>
           </div>
           <TableContainer>
-            <DataTable rows={rows} headers={headers} isSortable={true}>
+            <DataTable
+              rows={rows}
+              headers={headers}
+              isSortable={true}
+              size="short"
+            >
               {({ rows, headers, getHeaderProps, getTableProps }) => (
                 <Table {...getTableProps()}>
                   <TableHead>

--- a/src/widgets/appointments/appointments-overview.component.tsx
+++ b/src/widgets/appointments/appointments-overview.component.tsx
@@ -89,7 +89,9 @@ const AppointmentsOverview: React.FC<AppointmentOverviewProps> = () => {
       return (
         <div>
           <div className={styles.allergiesHeader}>
-            <h4>{headerTitle}</h4>
+            <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
+              {headerTitle}
+            </h4>
             <Button
               kind="ghost"
               renderIcon={Add16}

--- a/src/widgets/appointments/appointments-overview.scss
+++ b/src/widgets/appointments/appointments-overview.scss
@@ -4,5 +4,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: $spacing-03;
+  padding: $spacing-04 0 $spacing-04 $spacing-05;
+  background-color: $ui-background;
 }

--- a/src/widgets/biometrics/biometrics-overview.component.tsx
+++ b/src/widgets/biometrics/biometrics-overview.component.tsx
@@ -116,9 +116,9 @@ const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
     if (tableRows.length) {
       return (
         <div className={styles.biometricsWidgetContainer}>
-          <div className={styles.biometricHeaderContainer}>
+          <div className={styles.biometricsHeaderContainer}>
             <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
-              Biometrics
+              {headerTitle}
             </h4>
             <div className={styles.toggleButtons}>
               <Button
@@ -149,7 +149,6 @@ const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
               Add
             </Button>
           </div>
-
           {chartView ? (
             <>
               <BiometricsChart

--- a/src/widgets/biometrics/biometrics-overview.component.tsx
+++ b/src/widgets/biometrics/biometrics-overview.component.tsx
@@ -117,7 +117,9 @@ const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
       return (
         <div className={styles.biometricsWidgetContainer}>
           <div className={styles.biometricHeaderContainer}>
-            <h4>Biometrics</h4>
+            <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
+              Biometrics
+            </h4>
             <Button
               kind="ghost"
               renderIcon={Add16}

--- a/src/widgets/biometrics/biometrics-overview.component.tsx
+++ b/src/widgets/biometrics/biometrics-overview.component.tsx
@@ -9,7 +9,6 @@ import {
   Button,
   DataTable,
   DataTableSkeleton,
-  Link,
   Table,
   TableBody,
   TableCell,
@@ -127,7 +126,7 @@ const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
                 hasIconOnly
                 kind={chartView ? "ghost" : "secondary"}
                 renderIcon={Table16}
-                iconDescription="Table View"
+                iconDescription={t("tableView", "Table View")}
                 onClick={() => setChartView(false)}
               />
               <Button
@@ -136,7 +135,7 @@ const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
                 kind={chartView ? "secondary" : "ghost"}
                 hasIconOnly
                 renderIcon={ChartLineSmooth16}
-                iconDescription="Chart View"
+                iconDescription={t("chartView", "Chart View")}
                 onClick={() => setChartView(true)}
               />
             </div>
@@ -146,7 +145,7 @@ const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
               iconDescription="Add biometrics"
               onClick={launchBiometricsForm}
             >
-              Add
+              {t("add", "Add")}
             </Button>
           </div>
           {chartView ? (
@@ -204,14 +203,14 @@ const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
                                 }}
                               >
                                 {`${initialResultsDisplayed} / ${biometrics.length}`}{" "}
-                                items
+                                {t("items", "items")}
                               </span>
                               <Button
                                 size="small"
                                 kind="ghost"
                                 onClick={toggleAllResults}
                               >
-                                See all
+                                {t("seeAll", "See all")}
                               </Button>
                             </TableCell>
                           </TableRow>

--- a/src/widgets/biometrics/biometrics-overview.component.tsx
+++ b/src/widgets/biometrics/biometrics-overview.component.tsx
@@ -120,6 +120,26 @@ const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
             <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
               Biometrics
             </h4>
+            <div className={styles.toggleButtons}>
+              <Button
+                className={styles.toggle}
+                size="field"
+                hasIconOnly
+                kind={chartView ? "ghost" : "secondary"}
+                renderIcon={Table16}
+                iconDescription="Table View"
+                onClick={() => setChartView(false)}
+              />
+              <Button
+                className={styles.toggle}
+                size="field"
+                kind={chartView ? "secondary" : "ghost"}
+                hasIconOnly
+                renderIcon={ChartLineSmooth16}
+                iconDescription="Chart View"
+                onClick={() => setChartView(true)}
+              />
+            </div>
             <Button
               kind="ghost"
               renderIcon={Add16}
@@ -129,26 +149,7 @@ const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
               Add
             </Button>
           </div>
-          <div className={styles.toggleButtons}>
-            <Button
-              className={styles.toggle}
-              size="field"
-              hasIconOnly
-              kind={chartView ? "ghost" : "secondary"}
-              renderIcon={Table16}
-              iconDescription="Table View"
-              onClick={() => setChartView(false)}
-            />
-            <Button
-              className={styles.toggle}
-              size="field"
-              kind={chartView ? "secondary" : "ghost"}
-              hasIconOnly
-              renderIcon={ChartLineSmooth16}
-              iconDescription="Chart View"
-              onClick={() => setChartView(true)}
-            />
-          </div>
+
           {chartView ? (
             <>
               <BiometricsChart
@@ -172,6 +173,7 @@ const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
                       <TableRow>
                         {headers.map(header => (
                           <TableHeader
+                            className={`${styles.productiveHeading01} ${styles.text02}`}
                             {...getHeaderProps({
                               header,
                               isSortable: header.isSortable
@@ -192,16 +194,29 @@ const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
                           ))}
                         </TableRow>
                       ))}
-                      {biometrics.length > initialResultsDisplayed && (
-                        <TableRow>
-                          {!displayAllResults && (
+                      {!displayAllResults &&
+                        biometrics.length > initialResultsDisplayed && (
+                          <TableRow>
                             <TableCell colSpan={4}>
-                              {`${initialResultsDisplayed} / ${biometrics.length}`}{" "}
-                              <Link onClick={toggleAllResults}>See all</Link>
+                              <span
+                                style={{
+                                  display: "inline-block",
+                                  margin: "0.45rem 0rem"
+                                }}
+                              >
+                                {`${initialResultsDisplayed} / ${biometrics.length}`}{" "}
+                                items
+                              </span>
+                              <Button
+                                size="small"
+                                kind="ghost"
+                                onClick={toggleAllResults}
+                              >
+                                See all
+                              </Button>
                             </TableCell>
-                          )}
-                        </TableRow>
-                      )}
+                          </TableRow>
+                        )}
                     </TableBody>
                   </Table>
                 )}

--- a/src/widgets/biometrics/biometrics-overview.component.tsx
+++ b/src/widgets/biometrics/biometrics-overview.component.tsx
@@ -164,6 +164,7 @@ const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
                 headers={tableHeaders}
                 isSortable={true}
                 sortRow={sortRow}
+                size="short"
               >
                 {({ rows, headers, getHeaderProps, getTableProps }) => (
                   <Table {...getTableProps()}>

--- a/src/widgets/biometrics/biometrics-overview.scss
+++ b/src/widgets/biometrics/biometrics-overview.scss
@@ -10,13 +10,18 @@
   justify-content: space-between;
   align-items: center;
   padding: $spacing-03;
+  margin: 0 $spacing-03;
 }
 
 .toggleButtons {
   width: fit-content;
-  margin: 0 $spacing-03 $spacing-03 $spacing-03;
+  margin: 0 $spacing-03;
 }
 
-.toggle {
-  border-radius: 0.25rem;
+.toggle:first-of-type {
+  border-radius: $spacing-02 0 0 $spacing-02;
+}
+
+.toggle:last-of-type {
+  border-radius: 0 $spacing-02 $spacing-02 0;
 }

--- a/src/widgets/biometrics/biometrics-overview.scss
+++ b/src/widgets/biometrics/biometrics-overview.scss
@@ -5,12 +5,12 @@
   position: relative;
 }
 
-.biometricHeaderContainer {
+.biometricsHeaderContainer {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: $spacing-03;
-  margin: 0 $spacing-03;
+  padding: $spacing-04 0 $spacing-04 $spacing-05;
+  background-color: $ui-background;
 }
 
 .toggleButtons {

--- a/src/widgets/conditions/conditions-overview.component.tsx
+++ b/src/widgets/conditions/conditions-overview.component.tsx
@@ -91,7 +91,12 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = () => {
             </Button>
           </div>
           <TableContainer>
-            <DataTable rows={rows} headers={headers} isSortable={true}>
+            <DataTable
+              rows={rows}
+              headers={headers}
+              isSortable={true}
+              size="short"
+            >
               {({ rows, headers, getHeaderProps, getTableProps }) => (
                 <Table {...getTableProps()}>
                   <TableHead>

--- a/src/widgets/conditions/conditions-overview.component.tsx
+++ b/src/widgets/conditions/conditions-overview.component.tsx
@@ -78,7 +78,9 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = () => {
       return (
         <div>
           <div className={styles.conditionsHeader}>
-            <h4>{headerTitle}</h4>
+            <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
+              {headerTitle}
+            </h4>
             <Button
               kind="ghost"
               renderIcon={Add16}

--- a/src/widgets/conditions/conditions-overview.component.tsx
+++ b/src/widgets/conditions/conditions-overview.component.tsx
@@ -87,7 +87,7 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = () => {
               iconDescription="Add conditions"
               onClick={launchConditionsForm}
             >
-              Add
+              {t("add", "Add")}
             </Button>
           </div>
           <TableContainer>

--- a/src/widgets/conditions/conditions-overview.scss
+++ b/src/widgets/conditions/conditions-overview.scss
@@ -4,5 +4,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: $spacing-03;
+  padding: $spacing-04 0 $spacing-04 $spacing-05;
+  background-color: $ui-background;
 }

--- a/src/widgets/immunizations/immunizations-overview.component.tsx
+++ b/src/widgets/immunizations/immunizations-overview.component.tsx
@@ -94,7 +94,12 @@ const ImmunizationsOverview: React.FC<ImmunizationsOverviewProps> = () => {
             </Button>
           </div>
           <TableContainer>
-            <DataTable rows={rows} headers={headers} isSortable={true}>
+            <DataTable
+              rows={rows}
+              headers={headers}
+              isSortable={true}
+              size="short"
+            >
               {({ rows, headers, getHeaderProps, getTableProps }) => (
                 <Table {...getTableProps()}>
                   <TableHead>

--- a/src/widgets/immunizations/immunizations-overview.component.tsx
+++ b/src/widgets/immunizations/immunizations-overview.component.tsx
@@ -81,7 +81,9 @@ const ImmunizationsOverview: React.FC<ImmunizationsOverviewProps> = () => {
       return (
         <div>
           <div className={styles.immunizationsHeader}>
-            <h4>{headerTitle}</h4>
+            <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
+              {headerTitle}
+            </h4>
             <Button
               kind="ghost"
               renderIcon={Add16}

--- a/src/widgets/immunizations/immunizations-overview.component.tsx
+++ b/src/widgets/immunizations/immunizations-overview.component.tsx
@@ -26,7 +26,7 @@ import { performPatientImmunizationsSearch } from "./immunizations.resource";
 import { ImmunizationsForm } from "./immunizations-form.component";
 import EmptyState from "../../ui-components/empty-state/empty-state.component";
 import ErrorState from "../../ui-components/error-state/error-state.component";
-import styles from "./immunizations-overview.css";
+import styles from "./immunizations-overview.scss";
 
 const ImmunizationsOverview: React.FC<ImmunizationsOverviewProps> = () => {
   const { t } = useTranslation();

--- a/src/widgets/immunizations/immunizations-overview.component.tsx
+++ b/src/widgets/immunizations/immunizations-overview.component.tsx
@@ -90,7 +90,7 @@ const ImmunizationsOverview: React.FC<ImmunizationsOverviewProps> = () => {
               iconDescription="Add immunizations"
               onClick={launchImmunizationsForm}
             >
-              Add
+              {t("add", "Add")}
             </Button>
           </div>
           <TableContainer>

--- a/src/widgets/immunizations/immunizations-overview.scss
+++ b/src/widgets/immunizations/immunizations-overview.scss
@@ -1,3 +1,13 @@
+@import "../../root.scss";
+
+.immunizationsHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: $spacing-04 0 $spacing-04 $spacing-05;
+  background-color: $ui-background;
+}
+
 .immunizationOverviewSummaryCard {
   margin: 1.25rem 1.5rem;
 }

--- a/src/widgets/notes/notes-overview.component.tsx
+++ b/src/widgets/notes/notes-overview.component.tsx
@@ -82,7 +82,9 @@ const NotesOverview: React.FC<NotesOverviewProps> = () => {
       return (
         <div>
           <div className={styles.notesHeader}>
-            <h4>{headerTitle}</h4>
+            <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
+              {headerTitle}
+            </h4>
             <Button
               kind="ghost"
               renderIcon={Add16}

--- a/src/widgets/notes/notes-overview.component.tsx
+++ b/src/widgets/notes/notes-overview.component.tsx
@@ -91,7 +91,7 @@ const NotesOverview: React.FC<NotesOverviewProps> = () => {
               iconDescription="Add visit note"
               onClick={launchVisitNoteForm}
             >
-              Add
+              {t("add", "Add")}
             </Button>
           </div>
           <TableContainer>

--- a/src/widgets/notes/notes-overview.component.tsx
+++ b/src/widgets/notes/notes-overview.component.tsx
@@ -95,7 +95,12 @@ const NotesOverview: React.FC<NotesOverviewProps> = () => {
             </Button>
           </div>
           <TableContainer>
-            <DataTable rows={rows} headers={headers} isSortable={true}>
+            <DataTable
+              rows={rows}
+              headers={headers}
+              isSortable={true}
+              size="short"
+            >
               {({ rows, headers, getHeaderProps, getTableProps }) => (
                 <Table {...getTableProps()}>
                   <TableHead>

--- a/src/widgets/notes/notes-overview.scss
+++ b/src/widgets/notes/notes-overview.scss
@@ -4,5 +4,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: $spacing-03;
+  padding: $spacing-04 0 $spacing-04 $spacing-05;
+  background-color: $ui-background;
 }

--- a/src/widgets/programs/programs-overview.component.tsx
+++ b/src/widgets/programs/programs-overview.component.tsx
@@ -81,7 +81,7 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = props => {
               iconDescription="Add programs"
               onClick={launchProgramsForm}
             >
-              Add
+              {t("add", "Add")}
             </Button>
           </div>
           <TableContainer>

--- a/src/widgets/programs/programs-overview.component.tsx
+++ b/src/widgets/programs/programs-overview.component.tsx
@@ -85,7 +85,12 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = props => {
             </Button>
           </div>
           <TableContainer>
-            <DataTable rows={rows} headers={headers} isSortable={true}>
+            <DataTable
+              rows={rows}
+              headers={headers}
+              isSortable={true}
+              size="short"
+            >
               {({ rows, headers, getHeaderProps, getTableProps }) => (
                 <Table {...getTableProps()}>
                   <TableHead>

--- a/src/widgets/programs/programs-overview.component.tsx
+++ b/src/widgets/programs/programs-overview.component.tsx
@@ -72,7 +72,9 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = props => {
       return (
         <div>
           <div className={styles.programsHeader}>
-            <h4>{headerTitle}</h4>
+            <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
+              {headerTitle}
+            </h4>
             <Button
               kind="ghost"
               renderIcon={Add16}

--- a/src/widgets/programs/programs-overview.scss
+++ b/src/widgets/programs/programs-overview.scss
@@ -4,5 +4,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: $spacing-03;
+  padding: $spacing-04 0 $spacing-04 $spacing-05;
+  background-color: $ui-background;
 }

--- a/src/widgets/vitals/vitals-overview.component.tsx
+++ b/src/widgets/vitals/vitals-overview.component.tsx
@@ -111,6 +111,26 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ config }) => {
             <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
               Vitals
             </h4>
+            <div className={styles.toggleButtons}>
+              <Button
+                className={styles.toggle}
+                size="field"
+                kind={chartView ? "ghost" : "secondary"}
+                hasIconOnly
+                renderIcon={Table16}
+                iconDescription="Table View"
+                onClick={() => setChartView(false)}
+              />
+              <Button
+                className={styles.toggle}
+                size="field"
+                kind={chartView ? "secondary" : "ghost"}
+                hasIconOnly
+                renderIcon={ChartLineSmooth16}
+                iconDescription="Chart View"
+                onClick={() => setChartView(true)}
+              />
+            </div>
             <Button
               kind="ghost"
               renderIcon={Add16}
@@ -120,26 +140,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ config }) => {
               Add
             </Button>
           </div>
-          <div className={styles.toggleButtons}>
-            <Button
-              className={styles.toggle}
-              size="field"
-              kind={chartView ? "ghost" : "secondary"}
-              hasIconOnly
-              renderIcon={Table16}
-              iconDescription="Table View"
-              onClick={() => setChartView(false)}
-            />
-            <Button
-              className={styles.toggle}
-              size="field"
-              kind={chartView ? "secondary" : "ghost"}
-              hasIconOnly
-              renderIcon={ChartLineSmooth16}
-              iconDescription="Chart View"
-              onClick={() => setChartView(true)}
-            />
-          </div>
+
           {chartView ? (
             <>
               <VitalsChart
@@ -162,6 +163,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ config }) => {
                       <TableRow>
                         {headers.map(header => (
                           <TableHeader
+                            className={`${styles.productiveHeading01} ${styles.text02}`}
                             {...getHeaderProps({
                               header,
                               isSortable: header.isSortable
@@ -186,8 +188,22 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ config }) => {
                         currentVitals?.length > initialResultsDisplayed && (
                           <TableRow>
                             <TableCell colSpan={4}>
-                              {`${initialResultsDisplayed} / ${currentVitals.length}`}{" "}
-                              <Link onClick={toggleAllResults}>See all</Link>
+                              <span
+                                style={{
+                                  display: "inline-block",
+                                  margin: "0.45rem 0rem"
+                                }}
+                              >
+                                {`${initialResultsDisplayed} / ${currentVitals.length}`}{" "}
+                                items
+                              </span>
+                              <Button
+                                size="small"
+                                kind="ghost"
+                                onClick={toggleAllResults}
+                              >
+                                See all
+                              </Button>
                             </TableCell>
                           </TableRow>
                         )}

--- a/src/widgets/vitals/vitals-overview.component.tsx
+++ b/src/widgets/vitals/vitals-overview.component.tsx
@@ -154,6 +154,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ config }) => {
                 rows={tableRows}
                 headers={tableHeaders}
                 isSortable={true}
+                size="short"
               >
                 {({ rows, headers, getHeaderProps, getTableProps }) => (
                   <Table {...getTableProps()}>

--- a/src/widgets/vitals/vitals-overview.component.tsx
+++ b/src/widgets/vitals/vitals-overview.component.tsx
@@ -107,9 +107,9 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ config }) => {
     if (tableRows.length) {
       return (
         <div className={styles.vitalsWidgetContainer}>
-          <div className={styles.biometricHeaderContainer}>
+          <div className={styles.vitalsHeaderContainer}>
             <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
-              Vitals
+              {headerTitle}
             </h4>
             <div className={styles.toggleButtons}>
               <Button

--- a/src/widgets/vitals/vitals-overview.component.tsx
+++ b/src/widgets/vitals/vitals-overview.component.tsx
@@ -108,7 +108,9 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ config }) => {
       return (
         <div className={styles.vitalsWidgetContainer}>
           <div className={styles.biometricHeaderContainer}>
-            <h4>Vitals</h4>
+            <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
+              Vitals
+            </h4>
             <Button
               kind="ghost"
               renderIcon={Add16}

--- a/src/widgets/vitals/vitals-overview.component.tsx
+++ b/src/widgets/vitals/vitals-overview.component.tsx
@@ -6,17 +6,16 @@ import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { switchTo } from "@openmrs/esm-extensions";
 
 import {
-  TableContainer,
-  DataTable,
-  Table,
-  TableHead,
-  TableRow,
-  TableHeader,
-  TableBody,
-  TableCell,
   Button,
-  Link,
-  DataTableSkeleton
+  DataTable,
+  DataTableSkeleton,
+  Table,
+  TableCell,
+  TableContainer,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow
 } from "carbon-components-react";
 import { Add16, ChartLineSmooth16, Table16 } from "@carbon/icons-react";
 
@@ -118,7 +117,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ config }) => {
                 kind={chartView ? "ghost" : "secondary"}
                 hasIconOnly
                 renderIcon={Table16}
-                iconDescription="Table View"
+                iconDescription={t("tableView", "Table View")}
                 onClick={() => setChartView(false)}
               />
               <Button
@@ -127,7 +126,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ config }) => {
                 kind={chartView ? "secondary" : "ghost"}
                 hasIconOnly
                 renderIcon={ChartLineSmooth16}
-                iconDescription="Chart View"
+                iconDescription={t("chartView", "Chart View")}
                 onClick={() => setChartView(true)}
               />
             </div>
@@ -137,10 +136,9 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ config }) => {
               iconDescription="Add vitals"
               onClick={launchVitalsBiometricsForm}
             >
-              Add
+              {t("add", "Add")}
             </Button>
           </div>
-
           {chartView ? (
             <>
               <VitalsChart
@@ -195,14 +193,14 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ config }) => {
                                 }}
                               >
                                 {`${initialResultsDisplayed} / ${currentVitals.length}`}{" "}
-                                items
+                                {t("items", "items")}
                               </span>
                               <Button
                                 size="small"
                                 kind="ghost"
                                 onClick={toggleAllResults}
                               >
-                                See all
+                                {t("seeAll", "See all")}
                               </Button>
                             </TableCell>
                           </TableRow>

--- a/src/widgets/vitals/vitals-overview.scss
+++ b/src/widgets/vitals/vitals-overview.scss
@@ -1,14 +1,14 @@
 @import "../../root.scss";
 
-.biometricContainer {
+.vitalsWidgetContainer {
   background-color: $ui-background;
 }
 
-.biometricHeaderContainer {
+.vitalsHeaderContainer {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: $spacing-03;
+  padding: $spacing-04 0 $spacing-04 $spacing-05;
 }
 
 .toggleButtons {

--- a/src/widgets/vitals/vitals-overview.scss
+++ b/src/widgets/vitals/vitals-overview.scss
@@ -13,11 +13,15 @@
 
 .toggleButtons {
   width: fit-content;
-  margin: 0 $spacing-03 $spacing-03 $spacing-03;
+  margin: 0 $spacing-03;
 }
 
-.toggle {
-  border-radius: 0.25rem;
+.toggle:first-of-type {
+  border-radius: $spacing-02 0 0 $spacing-02;
+}
+
+.toggle:last-of-type {
+  border-radius: 0 $spacing-02 $spacing-02 0;
 }
 
 .vitalsWidgetContainer {


### PR DESCRIPTION
Building on top of @brandones work [here](https://github.com/openmrs/openmrs-esm-core/pull/61), this PR introduces a swathe of changes to the overview widgets UI:

- Change the datatable row sizing to a smaller size per the [designs](https://app.zeplin.io/project/5f7223cfda10f94d67cec6d0/screen/5fa4406fd62f63a00269c94b) using the `short` modifier.
- Change the datatable header style to match the designs (white background with content toggles center-aligned when present).
- Tweak the vitals and biometrics widget font style and pagination row content to match the [designs](https://app.zeplin.io/project/5f7223cfda10f94d67cec6d0/screen/5fa4406fd62f63a00269c94b). 

![Screenshot 2021-02-04 at 16 47 06](https://user-images.githubusercontent.com/8509731/106901299-9f99fb00-6708-11eb-9cdf-4b90297eb61e.png)

![Screenshot 2021-02-04 at 16 47 18](https://user-images.githubusercontent.com/8509731/106901314-a58fdc00-6708-11eb-94f4-2dc8a7f778e4.png)

![Screenshot 2021-02-04 at 16 47 33](https://user-images.githubusercontent.com/8509731/106901340-ae80ad80-6708-11eb-8b39-3cfc92b41192.png)

Next step: Adding a border underneath the widget header name styled with the OpenMRS branding colour like so:

![Screenshot 2021-02-04 at 16 49 13](https://user-images.githubusercontent.com/8509731/106901508-ec7dd180-6708-11eb-9f76-8073310656b4.png)

