### PR TITLE
Change datatable header typography

### DIFF
--- a/src/widgets/allergies/allergies-overview.component.tsx
+++ b/src/widgets/allergies/allergies-overview.component.tsx
@@ -102,6 +102,7 @@ const AllergiesOverview: React.FC<AllergiesOverviewProps> = () => {
                     <TableRow>
                       {headers.map(header => (
                         <TableHeader
+                          className={`${styles.productiveHeading01} ${styles.text02}`}
                           {...getHeaderProps({
                             header,
                             isSortable: header.isSortable

--- a/src/widgets/appointments/appointments-overview.component.tsx
+++ b/src/widgets/appointments/appointments-overview.component.tsx
@@ -114,6 +114,7 @@ const AppointmentsOverview: React.FC<AppointmentOverviewProps> = () => {
                     <TableRow>
                       {headers.map(header => (
                         <TableHeader
+                          className={`${styles.productiveHeading01} ${styles.text02}`}
                           {...getHeaderProps({
                             header,
                             isSortable: header.isSortable

--- a/src/widgets/conditions/conditions-overview.component.tsx
+++ b/src/widgets/conditions/conditions-overview.component.tsx
@@ -103,6 +103,7 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = () => {
                     <TableRow>
                       {headers.map(header => (
                         <TableHeader
+                          className={`${styles.productiveHeading01} ${styles.text02}`}
                           {...getHeaderProps({
                             header,
                             isSortable: header.isSortable

--- a/src/widgets/immunizations/immunizations-overview.component.tsx
+++ b/src/widgets/immunizations/immunizations-overview.component.tsx
@@ -106,6 +106,7 @@ const ImmunizationsOverview: React.FC<ImmunizationsOverviewProps> = () => {
                     <TableRow>
                       {headers.map(header => (
                         <TableHeader
+                          className={`${styles.productiveHeading01} ${styles.text02}`}
                           {...getHeaderProps({
                             header,
                             isSortable: header.isSortable

--- a/src/widgets/notes/notes-overview.component.tsx
+++ b/src/widgets/notes/notes-overview.component.tsx
@@ -107,6 +107,7 @@ const NotesOverview: React.FC<NotesOverviewProps> = () => {
                     <TableRow>
                       {headers.map(header => (
                         <TableHeader
+                          className={`${styles.productiveHeading01} ${styles.text02}`}
                           {...getHeaderProps({
                             header,
                             isSortable: header.isSortable

--- a/src/widgets/programs/programs-overview.component.tsx
+++ b/src/widgets/programs/programs-overview.component.tsx
@@ -97,6 +97,7 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = props => {
                     <TableRow>
                       {headers.map(header => (
                         <TableHeader
+                          className={`${styles.productiveHeading01} ${styles.text02}`}
                           {...getHeaderProps({
                             header,
                             isSortable: header.isSortable


### PR DESCRIPTION
This PR changes the typography of the widget datatable table headers to match the [designs](zpl://screen?pid=5f7223cfda10f94d67cec6d0&sid=5fa4407a5f96c602cc7114c6):

- Applies the carbon typography style type `productive-heading-01` with the carbon `text-02` color variable.

![Screenshot 2021-02-05 at 14 29 43](https://user-images.githubusercontent.com/8509731/107029123-961f9a00-67bf-11eb-9ebd-0db5fb049709.png)
