### PR TITLE
Fix datatable table header cell margins

### DIFF
--- a/src/root.scss
+++ b/src/root.scss
@@ -19,7 +19,6 @@ $interactive-01: #0f62fe;
 
 .productiveHeading01 {
   @include carbon--type-style("productive-heading-01");
-  margin-bottom: $spacing-03;
 }
 
 .productiveHeading02 {


### PR DESCRIPTION
Datatable header cells currently have a `0.5rem` bottom margin that makes its content look imbalanced. This margin was added as a property to the wrapper CSS class for the carbon `productive-heading-01` [type style](https://www.carbondesignsystem.com/guidelines/typography/productive/). Removing this custom margin fixes the presentation of the header cell content.

Before: 

![Screenshot 2021-02-08 at 14 22 27](https://user-images.githubusercontent.com/8509731/107213341-4b995a00-6a19-11eb-9c8c-4d57b306afb3.png)

After:

![Screenshot 2021-02-08 at 14 21 53](https://user-images.githubusercontent.com/8509731/107213385-5e139380-6a19-11eb-8b54-ee447dcb9dd9.png)

Note the extra space under the `Name` and `Reactions` labels.