### PR TITLE
Add brand color to table header title bottom borders

### DIFF
--- a/src/root.scss
+++ b/src/root.scss
@@ -16,6 +16,7 @@ $warning-background: #fff8e1;
 $openmrs-background-grey: #f4f4f4;
 $danger: #da1e28;
 $interactive-01: #0f62fe;
+$brand-teal-01: #007d79;
 
 .productiveHeading01 {
   @include carbon--type-style("productive-heading-01");

--- a/src/ui-components/empty-state/empty-state.scss
+++ b/src/ui-components/empty-state/empty-state.scss
@@ -19,6 +19,14 @@
   color: $text-02;
 }
 
+.heading:after {
+  content: "";
+  display: block;
+  width: 2rem;
+  padding-top: 0.188rem;
+  border-bottom: 0.375rem solid $brand-teal-01;
+}
+
 .tile {
   text-align: center;
 }

--- a/src/ui-components/error-state/error-state.scss
+++ b/src/ui-components/error-state/error-state.scss
@@ -21,6 +21,14 @@
   color: $text-02;
 }
 
+.heading:after {
+  content: "";
+  display: block;
+  width: 2rem;
+  padding-top: 0.188rem;
+  border-bottom: 0.375rem solid $brand-teal-01;
+}
+
 .tile {
   text-align: center;
 }

--- a/src/widgets/allergies/allergies-overview.scss
+++ b/src/widgets/allergies/allergies-overview.scss
@@ -7,3 +7,11 @@
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
 }
+
+.allergiesHeader > h4:after {
+  content: "";
+  display: block;
+  width: 2rem;
+  padding-top: 0.188rem;
+  border-bottom: 0.375rem solid $brand-teal-01;
+}

--- a/src/widgets/biometrics/biometrics-overview.scss
+++ b/src/widgets/biometrics/biometrics-overview.scss
@@ -13,6 +13,14 @@
   background-color: $ui-background;
 }
 
+.biometricsHeaderContainer > h4:after {
+  content: "";
+  display: block;
+  width: 2rem;
+  padding-top: 0.188rem;
+  border-bottom: 0.375rem solid $brand-teal-01;
+}
+
 .toggleButtons {
   width: fit-content;
   margin: 0 $spacing-03;

--- a/src/widgets/conditions/conditions-overview.scss
+++ b/src/widgets/conditions/conditions-overview.scss
@@ -7,3 +7,11 @@
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
 }
+
+.conditionsHeader > h4:after {
+  content: "";
+  display: block;
+  width: 2rem;
+  padding-top: 0.188rem;
+  border-bottom: 0.375rem solid $brand-teal-01;
+}

--- a/src/widgets/notes/notes-overview.scss
+++ b/src/widgets/notes/notes-overview.scss
@@ -7,3 +7,11 @@
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
 }
+
+.notesHeader > h4:after {
+  content: "";
+  display: block;
+  width: 2rem;
+  padding-top: 0.188rem;
+  border-bottom: 0.375rem solid $brand-teal-01;
+}

--- a/src/widgets/programs/programs-overview.scss
+++ b/src/widgets/programs/programs-overview.scss
@@ -7,3 +7,11 @@
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
 }
+
+.programsHeader > h4:after {
+  content: "";
+  display: block;
+  width: 2rem;
+  padding-top: 0.188rem;
+  border-bottom: 0.375rem solid $brand-teal-01;
+}

--- a/src/widgets/vitals/vitals-overview.scss
+++ b/src/widgets/vitals/vitals-overview.scss
@@ -11,6 +11,14 @@
   padding: $spacing-04 0 $spacing-04 $spacing-05;
 }
 
+.vitalsHeaderContainer > h4:after {
+  content: "";
+  display: block;
+  width: 2rem;
+  padding-top: 0.188rem;
+  border-bottom: 0.375rem solid $brand-teal-01;
+}
+
 .toggleButtons {
   width: fit-content;
   margin: 0 $spacing-03;


### PR DESCRIPTION
Adds a bottom border to the header titles of datatables in the overview widgets with brand colouring, per the [designs](https://app.zeplin.io/project/5f7223cfda10f94d67cec6d0/dashboard?sid=5fa4406fd62f63a00269c94b).

<img width="1505" alt="Screenshot 2021-02-08 at 22 28 22" src="https://user-images.githubusercontent.com/8509731/107272229-6fcb5a00-6a5e-11eb-81f9-29669373fa95.png">
