### PR TITLE
Change default items to show count to 5

### DIFF
--- a/src/widgets/allergies/allergies-overview.component.tsx
+++ b/src/widgets/allergies/allergies-overview.component.tsx
@@ -31,7 +31,7 @@ import ErrorState from "../../ui-components/error-state/error-state.component";
 import styles from "./allergies-overview.scss";
 
 const AllergiesOverview: React.FC<AllergiesOverviewProps> = () => {
-  const allergiesToShowCount = 3;
+  const allergiesToShowCount = 5;
   const { t } = useTranslation();
   const [isLoadingPatient, patient] = useCurrentPatient();
   const [allergies, setAllergies] = React.useState<Array<Allergy>>(null);

--- a/src/widgets/appointments/appointments-overview.component.tsx
+++ b/src/widgets/appointments/appointments-overview.component.tsx
@@ -31,7 +31,7 @@ import styles from "./appointments-overview.scss";
 
 const AppointmentsOverview: React.FC<AppointmentOverviewProps> = () => {
   const { t } = useTranslation();
-  const appointmentsToShowCount = 3;
+  const appointmentsToShowCount = 5;
   const [isLoadingPatient, , patientUuid] = useCurrentPatient();
   const [appointments, setAppointments] = React.useState(null);
   const [error, setError] = React.useState(null);

--- a/src/widgets/biometrics/biometrics-overview.component.tsx
+++ b/src/widgets/biometrics/biometrics-overview.component.tsx
@@ -39,7 +39,7 @@ export interface PatientBiometrics {
 }
 
 const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
-  const biometricsToShowCount = 3;
+  const biometricsToShowCount = 5;
   const { t } = useTranslation();
   const [, , patientUuid] = useCurrentPatient();
   const { conceptsUnits } = useVitalsSignsConceptMetaData();
@@ -51,25 +51,6 @@ const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
   const headerTitle = t("biometrics", "Biometrics");
   const [, , , heightUnit, weightUnit] = conceptsUnits;
   const [chartView, setChartView] = React.useState<boolean>();
-
-  const tableHeaders = [
-    { key: "date", header: "Date" },
-    { key: "weight", header: `Weight (${weightUnit})` },
-    { key: "height", header: `Height (${heightUnit})` },
-    { key: "bmi", header: `BMI (${bmiUnit})` }
-  ];
-
-  const tableRows = biometrics
-    ?.slice(0, showAllBiometrics ? biometrics.length : 3)
-    ?.map((biometric: PatientBiometrics, index) => {
-      return {
-        id: `${index}`,
-        date: dayjs(biometric.date).format(`DD - MMM - YYYY`),
-        weight: biometric.weight,
-        height: biometric.height,
-        bmi: biometric.bmi
-      };
-    });
 
   React.useEffect(() => {
     if (patientUuid) {
@@ -87,6 +68,25 @@ const BiometricsOverview: React.FC<BiometricsOverviewProps> = ({ config }) => {
       return () => sub.unsubscribe();
     }
   }, [patientUuid, config.concepts.weightUuid, config.concepts.heightUuid]);
+
+  const tableHeaders = [
+    { key: "date", header: "Date" },
+    { key: "weight", header: `Weight (${weightUnit})` },
+    { key: "height", header: `Height (${heightUnit})` },
+    { key: "bmi", header: `BMI (${bmiUnit})` }
+  ];
+
+  const tableRows = biometrics
+    ?.slice(0, showAllBiometrics ? biometrics.length : biometricsToShowCount)
+    ?.map((biometric: PatientBiometrics, index) => {
+      return {
+        id: `${index}`,
+        date: dayjs(biometric.date).format(`DD - MMM - YYYY`),
+        weight: biometric.weight,
+        height: biometric.height,
+        bmi: biometric.bmi
+      };
+    });
 
   const toggleShowAllBiometrics = () => {
     setShowAllBiometrics(!showAllBiometrics);

--- a/src/widgets/conditions/conditions-overview.component.tsx
+++ b/src/widgets/conditions/conditions-overview.component.tsx
@@ -32,7 +32,7 @@ import {
 import styles from "./conditions-overview.scss";
 
 const ConditionsOverview: React.FC<ConditionsOverviewProps> = () => {
-  const conditionsToShowCount = 3;
+  const conditionsToShowCount = 5;
   const { t } = useTranslation();
   const [, patient] = useCurrentPatient();
   const [conditions, setConditions] = React.useState<Array<Condition>>(null);

--- a/src/widgets/conditions/conditions-overview.test.tsx
+++ b/src/widgets/conditions/conditions-overview.test.tsx
@@ -52,13 +52,16 @@ describe("<ConditionsOverview />", () => {
     expect(screen.getByText("Feb-2019")).toBeInTheDocument();
     expect(screen.getByText("Anosmia")).toBeInTheDocument();
     expect(screen.getByText("Oct-2020")).toBeInTheDocument();
-    expect(screen.getByText(/3 \/ 6 items/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Generalized skin infection due to AIDS/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/5 \/ 6 items/)).toBeInTheDocument();
     const expandConditionsBtn = screen.getByRole("button", { name: "See all" });
     expect(expandConditionsBtn).toBeInTheDocument();
     fireEvent.click(expandConditionsBtn);
-    await screen.findByText(/Generalized skin infection due to AIDS/i);
-    expect(screen.getByText("Cough")).toBeInTheDocument();
+    await screen.findByText(/Rash/i);
     expect(screen.getByText("Rash")).toBeInTheDocument();
+    expect(screen.getByText("Cough")).toBeInTheDocument();
   });
 
   it("renders an empty state view when conditions data is absent", async () => {

--- a/src/widgets/immunizations/immunizations-overview.component.tsx
+++ b/src/widgets/immunizations/immunizations-overview.component.tsx
@@ -29,7 +29,7 @@ import ErrorState from "../../ui-components/error-state/error-state.component";
 import styles from "./immunizations-overview.scss";
 
 const ImmunizationsOverview: React.FC<ImmunizationsOverviewProps> = () => {
-  const immunizationsToShowCount = 3;
+  const immunizationsToShowCount = 5;
   const { t } = useTranslation();
   const [immunizations, setImmunizations] = React.useState(null);
   const [error, setError] = React.useState(null);

--- a/src/widgets/notes/notes-overview.component.tsx
+++ b/src/widgets/notes/notes-overview.component.tsx
@@ -30,7 +30,7 @@ import { formatNotesDate } from "./notes-helper";
 import styles from "./notes-overview.scss";
 
 const NotesOverview: React.FC<NotesOverviewProps> = () => {
-  const notesToShowCount = 3;
+  const notesToShowCount = 5;
   const { t } = useTranslation();
   const [, patient, patientUuid] = useCurrentPatient();
   const [notes, setNotes] = React.useState<Array<PatientNote>>(null);

--- a/src/widgets/programs/programs-overview.component.tsx
+++ b/src/widgets/programs/programs-overview.component.tsx
@@ -30,7 +30,7 @@ import { PatientProgram } from "../types";
 import styles from "./programs-overview.scss";
 
 const ProgramsOverview: React.FC<ProgramsOverviewProps> = () => {
-  const programsToShowCount = 3;
+  const programsToShowCount = 5;
   const { t } = useTranslation();
   const [, , patientUuid] = useCurrentPatient();
   const [programs, setPrograms] = React.useState<Array<PatientProgram>>(null);

--- a/src/widgets/vitals/vitals-overview.component.tsx
+++ b/src/widgets/vitals/vitals-overview.component.tsx
@@ -33,7 +33,7 @@ import VitalsChart from "./vitals-chart.component";
 import FloatingButton from "../../ui-components/floating-button/floating-button.component";
 
 const VitalsOverview: React.FC<VitalsOverviewProps> = ({ config }) => {
-  const vitalsToShowCount = 3;
+  const vitalsToShowCount = 5;
   const { t } = useTranslation();
   const {
     vitalsSignsConceptMetadata,


### PR DESCRIPTION
Changes the number of results to display in the widget datatables to 5 as is the case in the [new](https://app.zeplin.io/project/5f7223cfda10f94d67cec6d0/screen/5fa4406fd62f63a00269c94b) designs.

<img width="738" alt="Screenshot 2021-02-08 at 22 56 44" src="https://user-images.githubusercontent.com/8509731/107274055-fd0fae00-6a60-11eb-8650-819c24dd6498.png">