### PR TITLE
Fixes some unit tests and adds some appropriate typing

### DIFF
--- a/src/widgets/conditions/conditions-detailed-summary.test.tsx
+++ b/src/widgets/conditions/conditions-detailed-summary.test.tsx
@@ -9,6 +9,7 @@ import { mockPatientConditionsResult } from "../../../__mocks__/conditions.mock"
 import ConditionsDetailedSummary from "./conditions-detailed-summary.component";
 import { performPatientConditionsSearch } from "./conditions.resource";
 import { openWorkspaceTab } from "../shared-utils";
+import dayjs from "dayjs";
 
 const mockOpenWorkspaceTab = openWorkspaceTab as jest.Mock;
 const mockPerformPatientConditionsSearch = performPatientConditionsSearch as jest.Mock;
@@ -29,6 +30,8 @@ jest.mock("../shared-utils", () => ({
   openWorkspaceTab: jest.fn()
 }));
 
+const renderDateDisplay = (time: string) => dayjs(time).format("MMM-YYYY");
+
 describe("<ConditionsDetailedSummary />", () => {
   beforeEach(() => {
     mockOpenWorkspaceTab.mockReset;
@@ -47,16 +50,32 @@ describe("<ConditionsDetailedSummary />", () => {
     expect(screen.getByText("Onset date")).toBeInTheDocument();
     expect(screen.getByText("Status")).toBeInTheDocument();
     expect(screen.getByText("Malaria, confirmed")).toBeInTheDocument();
-    expect(screen.getByText("Nov-2019")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        renderDateDisplay(mockPatientConditionsResult[0].onsetDateTime)
+      )
+    ).toBeInTheDocument();
     expect(screen.getAllByText("Active").length).toEqual(5);
     expect(screen.getByText("Anaemia")).toBeInTheDocument();
-    expect(screen.getByText("Feb-2019")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        renderDateDisplay(mockPatientConditionsResult[1].onsetDateTime)
+      )
+    ).toBeInTheDocument();
     expect(screen.getByText("Anosmia")).toBeInTheDocument();
-    expect(screen.getByText("Oct-2020")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        renderDateDisplay(mockPatientConditionsResult[2].onsetDateTime)
+      )
+    ).toBeInTheDocument();
     expect(
       screen.getByText(/Generalized skin infection due to AIDS/i)
     ).toBeInTheDocument();
-    expect(screen.getByText("Jun-2020")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        renderDateDisplay(mockPatientConditionsResult[3].onsetDateTime)
+      )
+    ).toBeInTheDocument();
     expect(screen.getByText("Inactive")).toBeInTheDocument();
   });
 

--- a/src/widgets/conditions/conditions-overview.test.tsx
+++ b/src/widgets/conditions/conditions-overview.test.tsx
@@ -9,6 +9,7 @@ import { performPatientConditionsSearch } from "./conditions.resource";
 import ConditionsOverview from "./conditions-overview.component";
 import { mockPatientConditionsResult } from "../../../__mocks__/conditions.mock";
 import { openWorkspaceTab } from "../shared-utils";
+import dayjs from "dayjs";
 
 const mockOpenWorkspaceTab = openWorkspaceTab as jest.Mock;
 const mockPerformPatientConditionsSearch = performPatientConditionsSearch as jest.Mock;
@@ -29,6 +30,8 @@ jest.mock("../shared-utils", () => ({
   openWorkspaceTab: jest.fn()
 }));
 
+const renderDateDisplay = (time: string) => dayjs(time).format("MMM-YYYY");
+
 describe("<ConditionsOverview />", () => {
   beforeEach(() => {
     mockOpenWorkspaceTab.mockReset;
@@ -47,11 +50,23 @@ describe("<ConditionsOverview />", () => {
     expect(screen.getByText("Active Conditions")).toBeInTheDocument();
     expect(screen.getByText("Since")).toBeInTheDocument();
     expect(screen.getByText("Malaria, confirmed")).toBeInTheDocument();
-    expect(screen.getByText("Nov-2019")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        renderDateDisplay(mockPatientConditionsResult[0].onsetDateTime)
+      )
+    ).toBeInTheDocument();
     expect(screen.getByText("Anaemia")).toBeInTheDocument();
-    expect(screen.getByText("Feb-2019")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        renderDateDisplay(mockPatientConditionsResult[1].onsetDateTime)
+      )
+    ).toBeInTheDocument();
     expect(screen.getByText("Anosmia")).toBeInTheDocument();
-    expect(screen.getByText("Oct-2020")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        renderDateDisplay(mockPatientConditionsResult[2].onsetDateTime)
+      )
+    ).toBeInTheDocument();
     expect(
       screen.getByText(/Generalized skin infection due to AIDS/i)
     ).toBeInTheDocument();

--- a/src/widgets/programs/program-record.component.tsx
+++ b/src/widgets/programs/program-record.component.tsx
@@ -45,7 +45,7 @@ export default function ProgramRecord(props: ProgramRecordProps) {
                   programUuid: patientProgram?.uuid,
                   enrollmentDate: patientProgram?.dateEnrolled,
                   completionDate: patientProgram?.dateCompleted,
-                  location: patientProgram?.location?.uuid
+                  locationUuid: patientProgram?.location?.uuid
                 }
               )
             }

--- a/src/widgets/programs/programs-form.component.tsx
+++ b/src/widgets/programs/programs-form.component.tsx
@@ -14,7 +14,7 @@ import { createErrorHandler } from "@openmrs/esm-error-handling";
 import SummaryCard from "../../ui-components/cards/summary-card.component";
 import dayjs from "dayjs";
 import { filter, includes, map } from "lodash-es";
-import { useHistory } from "react-router-dom";
+import { match, useHistory } from "react-router-dom";
 import { DataCaptureComponentProps } from "../shared-utils";
 import { useTranslation, Trans } from "react-i18next";
 
@@ -51,12 +51,12 @@ export default function ProgramsForm(props: ProgramsFormProps) {
       programUuid,
       enrollmentDate,
       completionDate,
-      location
+      locationUuid
     } = props.match.params;
 
     if (program && enrollmentDate) {
       setViewEditForm(true);
-      setLocation(location);
+      setLocation(locationUuid);
       setProgram(programUuid);
       setCompletionDate(completionDate);
       setEnrollmentDate(enrollmentDate);
@@ -494,7 +494,18 @@ ProgramsForm.defaultProps = {
   closeComponent: () => {}
 };
 
-type ProgramsFormProps = DataCaptureComponentProps & { match: any };
+type ProgramsFormProps = DataCaptureComponentProps & {
+  match: match<ProgramMatchProps>;
+};
+
+// exported so we can use this for tests
+export type ProgramMatchProps = {
+  program?: string;
+  programUuid?: string;
+  enrollmentDate?: string;
+  completionDate?: string;
+  locationUuid?: string;
+};
 
 type ProgramEnrollment = {
   program: string;


### PR DESCRIPTION
This PR does two things:

1. It fixes some tests that are broken for me due to timezone differences. I'm in UTC-0500 currently; a few tests rely on DayJS converting strings given in UTC to particular days; this works well if you are in UTC or UTC+<something>, but fails in UTC-<something>. For example, one test relied on the string "2020-10-01T00:00:00+00:00" converting to "Oct-2020" (using the "MMM-YYYY" format), but, of course, for my locale, it renders as "Sep-2020" because 2020-10-01T00:00:00+00:00 is 2020-09-30T19:00:00-05:00.

2. I added some types to the program-form which were necessary to do the above cleanly.
