### PR TITLE
MF-468: Fix Active Visit tag styling

### DIFF
--- a/src/widgets/banner/patient-banner.component.tsx
+++ b/src/widgets/banner/patient-banner.component.tsx
@@ -41,15 +41,10 @@ export default function PatientBanner() {
               <img src={placeholder} alt="Patient avatar" />
             </div>
             <div className={styles.patientInfo}>
-              <div className={(styles.row, styles.leftJustified)}>
+              <div className={(styles.row, styles.nameRow)}>
                 <span className={styles.patientName}>{getPatientNames()}</span>
                 {hasActiveVisit && (
-                  <Tag
-                    className={styles.patientActiveVisitIndicator}
-                    type="blue"
-                  >
-                    {t("Active Visit", "Active Visit")}
-                  </Tag>
+                  <Tag type="blue">{t("Active Visit", "Active Visit")}</Tag>
                 )}
               </div>
               <div className={styles.row}>

--- a/src/widgets/banner/patient-banner.scss
+++ b/src/widgets/banner/patient-banner.scss
@@ -11,7 +11,6 @@
 
 .patientName {
   @include carbon--type-style("productive-heading-03");
-  padding-top: 0.938rem;
   margin-right: 0.25rem;
 }
 
@@ -20,10 +19,6 @@
   height: 5rem;
   margin: 1rem;
   border-radius: 1px;
-}
-
-.patientActiveVisitIndicator {
-  margin-top: 0.938rem;
 }
 
 .patientInfo {
@@ -44,8 +39,11 @@
   margin-top: -0.125rem;
 }
 
-.leftJustified {
-  justify-content: left;
+.nameRow {
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  margin-top: 0.625rem;
 }
 
 .identifiers {


### PR DESCRIPTION
[Ticket](https://issues.openmrs.org/browse/MF-468)


Fixes the styling of the contents of the patient banner both when the Active Visit tag is present and when it's absent. This involves fixing the alignment of the patient name and Active Visit tag so that they align horizontally at the same level as the top of the patient avatar.

Before:

Patient name misaligned with the top of the avatar
<img width="576" alt="Screenshot 2021-02-11 at 21 10 49" src="https://user-images.githubusercontent.com/8509731/107684481-ea40e780-6cb3-11eb-9477-87246f60b156.png">

Aligned when Active Visit tag is present
<img width="577" alt="Screenshot 2021-02-11 at 21 06 32" src="https://user-images.githubusercontent.com/8509731/107684523-f6c54000-6cb3-11eb-8a54-cf88f8e6918f.png">

After:

Aligned in both cases
<img width="578" alt="Screenshot 2021-02-11 at 21 06 02" src="https://user-images.githubusercontent.com/8509731/107684655-16f4ff00-6cb4-11eb-95e0-5cb4e5009a18.png">

<img width="577" alt="Screenshot 2021-02-11 at 21 06 32" src="https://user-images.githubusercontent.com/8509731/107684679-1ceae000-6cb4-11eb-8cc0-79e66a56d720.png">