### PR TITLE
Implemented Forms with, with ability to launch form-entry  form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-chart-widgets",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2446,6 +2446,12 @@
         "@types/react": "*",
         "flatpickr": "4.6.1"
       }
+    },
+    "@types/carbon__icons-react": {
+      "version": "10.24.0",
+      "resolved": "https://registry.npmjs.org/@types/carbon__icons-react/-/carbon__icons-react-10.24.0.tgz",
+      "integrity": "sha512-cpsykaZQqh9oz43c/wxXhw5Z+0ngqB4nbf8DEAYS0h6BWVAor29439k2D5bRakyVzNj1sHbjnqLQ+rhFXcrJUg==",
+      "dev": true
     },
     "@types/fhir": {
       "version": "0.0.30",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@testing-library/user-event": "^12.5.0",
     "@types/carbon-components": "^10.23.0",
     "@types/carbon-components-react": "^7.24.0",
+    "@types/carbon__icons-react": "^10.24.0",
     "@types/jest": "^24.9.1",
     "@types/lodash-es": "^4.17.3",
     "@types/react": "^16.9.34",

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,6 +282,22 @@ function setupOpenMRS() {
             moduleName
           }
         )
+      },
+      {
+        id: "forms",
+        slot: "forms",
+        load: getAsyncExtensionLifecycle(
+          () => import("./widgets/forms/forms.component"),
+          { featureName: "forms", moduleName }
+        )
+      },
+      {
+        id: "form-entry",
+        slot: "/patient/:patientUuid/formentry",
+        load: getAsyncExtensionLifecycle(
+          () => import("./widgets/forms/form-entry.component"),
+          { featureName: "form-entry", moduleName }
+        )
       }
     ]
   };

--- a/src/widgets/forms/form-entry.component.tsx
+++ b/src/widgets/forms/form-entry.component.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { ExtensionSlot } from "@openmrs/esm-react-utils";
+import { switchTo } from "@openmrs/esm-extensions";
+
+interface FormEntryProps {
+  closeWorkspace?: () => void;
+  formUuid: string;
+  encounterUuid: string;
+}
+
+const FormEntry: React.FC<FormEntryProps> = ({
+  closeWorkspace,
+  formUuid,
+  encounterUuid
+}) => {
+  closeWorkspace = closeWorkspace ?? (() => switchTo("workspace", ""));
+
+  return (
+    <ExtensionSlot
+      extensionSlotName="form-widget"
+      state={{
+        formUuid: formUuid,
+        encounterUuid: encounterUuid,
+        view: "form",
+        closeWorkspace: closeWorkspace
+      }}
+    />
+  );
+};
+
+export default FormEntry;

--- a/src/widgets/forms/form-view.component.scss
+++ b/src/widgets/forms/form-view.component.scss
@@ -1,0 +1,39 @@
+@import "../../root.scss";
+
+.formContainer {
+  display: flex;
+  height: 12rem;
+  flex-direction: row;
+  flex-wrap: wrap;
+  overflow: scroll;
+}
+
+.customCheckBoxContainer {
+  height: 3rem;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  width: 16.25rem;
+  cursor: pointer;
+  margin: 0;
+  border: 0.0125rem solid transparent;
+}
+
+.customCheckBoxContainer:hover {
+  border: 0.0125rem solid $ui-03;
+  border-radius: 0.25rem;
+}
+
+.customCheckBoxContainer > svg {
+  flex: 2;
+  margin: 0;
+  fill: $color-blue-60-2;
+}
+
+.label {
+  flex: 8;
+  text-align: left;
+  color: $color-blue-60-2;
+  @extend .bodyShort01;
+}

--- a/src/widgets/forms/form-view.component.tsx
+++ b/src/widgets/forms/form-view.component.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import CheckmarkFilled16 from "@carbon/icons-react/es/checkmark--filled/16";
+import { switchTo } from "@openmrs/esm-extensions";
+import { useTranslation } from "react-i18next";
+import { Form } from "../types";
+import styles from "./form-view.component.scss";
+
+interface FormViewProps {
+  forms: Array<Form>;
+  patientUuid: string;
+  encounterUuid?: string;
+}
+
+interface checkBoxProps {
+  label: string;
+  form: Form;
+}
+
+const FormView: React.FC<FormViewProps> = ({
+  forms,
+  patientUuid,
+  encounterUuid
+}) => {
+  const { t } = useTranslation();
+  const launchFormEntry = form => {
+    const url = `/patient/${patientUuid}/formentry`;
+    switchTo("workspace", url, {
+      title: t("formEntry", `${form.name}`),
+      formUuid: form.uuid,
+      encounterUuid: encounterUuid
+    });
+  };
+
+  const CheckedComponent: React.FC<checkBoxProps> = ({ label, form }) => {
+    return (
+      <div
+        tabIndex={0}
+        role="button"
+        onClick={() => launchFormEntry(form)}
+        className={styles.customCheckBoxContainer}
+      >
+        <CheckmarkFilled16 />
+        <div className={styles.label}>{label}</div>
+      </div>
+    );
+  };
+
+  return (
+    <div className={styles.formContainer}>
+      {forms.map((form, index) => (
+        <CheckedComponent key={index} label={form.name} form={form} />
+      ))}
+    </div>
+  );
+};
+
+export default FormView;

--- a/src/widgets/forms/forms-utils.ts
+++ b/src/widgets/forms/forms-utils.ts
@@ -1,0 +1,32 @@
+import { Encounter, Form } from "../types";
+
+export function filterAvailableAndCompletedForms(
+  forms: Array<Form>,
+  encounters: Array<Encounter>
+): {
+  available: Array<Form>;
+  completed: Array<Encounter>;
+} {
+  const availability = {
+    available: [],
+    completed: []
+  };
+
+  forms.forEach(form => {
+    let completedEncounters = encounters.filter(encounter => {
+      return areFormsEqual(encounter.form, form);
+    });
+    if (completedEncounters.length > 0) {
+      availability.completed = availability.completed.concat(
+        completedEncounters
+      );
+    } else {
+      availability.available.push(form);
+    }
+  });
+  return availability;
+}
+
+export const areFormsEqual = (a: Form, b: Form): boolean => {
+  return a !== null && b !== null && a.uuid === b.uuid;
+};

--- a/src/widgets/forms/forms-utils.ts
+++ b/src/widgets/forms/forms-utils.ts
@@ -13,13 +13,11 @@ export function filterAvailableAndCompletedForms(
   };
 
   forms.forEach(form => {
-    let completedEncounters = encounters.filter(encounter => {
+    const completedEncounters = encounters.filter(encounter => {
       return areFormsEqual(encounter.form, form);
     });
     if (completedEncounters.length > 0) {
-      availability.completed = availability.completed.concat(
-        completedEncounters
-      );
+      availability.completed.push(...completedEncounters);
     } else {
       availability.available.push(form);
     }

--- a/src/widgets/forms/forms.component.scss
+++ b/src/widgets/forms/forms.component.scss
@@ -1,0 +1,44 @@
+@import "../../root.scss";
+
+.formsWidgetContainer {
+  background-color: $ui-background;
+  position: relative;
+  height: 19.25rem;
+}
+
+.formsHeaderContainer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: $spacing-04 0 $spacing-04 $spacing-05;
+  background-color: $ui-background;
+}
+
+.formsHeaderContainer > h4:after {
+  content: "";
+  display: block;
+  width: 2rem;
+  padding-top: 0.188rem;
+  border-bottom: 0.375rem solid $brand-teal-01;
+}
+
+.contextSwitcherContainer {
+  width: 60%;
+  margin-right: 1rem;
+}
+
+.contextSwitcherWidth {
+  width: 100%;
+  height: 48px;
+}
+
+.helperContainer {
+  color: $color-gray-70;
+  @extend .bodyShort01;
+  text-align: left;
+  padding-left: 1.3rem;
+}
+
+.labelRed {
+  color: $danger;
+}

--- a/src/widgets/forms/forms.component.tsx
+++ b/src/widgets/forms/forms.component.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import ContentSwitcher from "carbon-components-react/es/components/ContentSwitcher";
+import Switch from "carbon-components-react/es/components/Switch";
+import { Encounter, Form } from "../types";
+import { useTranslation } from "react-i18next";
+import { filterAvailableAndCompletedForms } from "./forms-utils";
+import { fetchAllForms, fetchPatientEncounters } from "./forms.resource";
+import { createErrorHandler } from "@openmrs/esm-error-handling";
+import { useCurrentPatient } from "@openmrs/esm-react-utils";
+import EmptyState from "../../ui-components/empty-state/empty-state.component";
+import FormView from "./form-view.component";
+import ErrorState from "../../ui-components/error-state/error-state.component";
+import styles from "./forms.component.scss";
+import dayjs from "dayjs";
+import first from "lodash-es/first";
+
+enum formView {
+  recommended = 0,
+  completed,
+  all
+}
+
+const Forms: React.FC<any> = () => {
+  const { t } = useTranslation();
+  const displayText = t("forms", "Forms");
+  const headerTitle = t("forms", "Forms");
+  const [error, setError] = React.useState(null);
+  const [allForms, setAllForms] = React.useState<Array<Form>>([]);
+  const [encounters, setEncounters] = React.useState<Array<Encounter>>([]);
+  const [completedForms, setCompletedForms] = React.useState<Array<Form>>([]);
+  const [selectedFormView, setSelectedFormView] = React.useState<formView>(
+    formView.all
+  );
+  const [, , patientUuid] = useCurrentPatient();
+
+  React.useEffect(() => {
+    fetchAllForms().subscribe(
+      forms => setAllForms(forms),
+      error => {
+        createErrorHandler();
+        setError(error);
+      }
+    );
+  }, []);
+
+  React.useEffect(() => {
+    const fromDate = dayjs(new Date()).startOf("day");
+    const toDate = dayjs(new Date()).endOf("day");
+    fetchPatientEncounters(
+      patientUuid,
+      fromDate.toDate(),
+      toDate.toDate()
+    ).subscribe(
+      encounters => setEncounters(encounters),
+      error => {
+        createErrorHandler(), setError(error);
+      }
+    );
+  }, [patientUuid]);
+
+  React.useEffect(() => {
+    const availableForms = filterAvailableAndCompletedForms(
+      allForms,
+      encounters
+    );
+    const completedForms = availableForms.completed.map(
+      encounters => encounters.form
+    );
+    setCompletedForms(completedForms);
+  }, [allForms, encounters]);
+
+  const RenderForm = () => {
+    return (
+      <div className={styles.formsWidgetContainer}>
+        <div className={styles.formsHeaderContainer}>
+          <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
+            {headerTitle}
+          </h4>
+          <div className={styles.contextSwitcherContainer}>
+            <ContentSwitcher
+              className={styles.contextSwitcherWidth}
+              onChange={event => setSelectedFormView(event.name as any)}
+              selectedIndex={selectedFormView}
+            >
+              <Switch name={formView.recommended} text="Recommended" />
+              <Switch name={formView.completed} text="Completed" />
+              <Switch name={formView.all} text="All" />
+            </ContentSwitcher>
+          </div>
+        </div>
+        <div>
+          <p className={styles.helperContainer}>
+            Actions marked with <span className={styles.labelRed}>*</span> are
+            required
+          </p>
+          {selectedFormView === formView.completed && (
+            <FormView
+              forms={completedForms}
+              patientUuid={patientUuid}
+              encounterUuid={first<Encounter>(encounters)?.uuid}
+            />
+          )}
+          {selectedFormView === formView.all && (
+            <FormView
+              forms={allForms}
+              patientUuid={patientUuid}
+              encounterUuid={first<Encounter>(encounters)?.uuid}
+            />
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      {allForms ? (
+        <RenderForm />
+      ) : error ? (
+        <ErrorState error={error} headerTitle={headerTitle} />
+      ) : (
+        <EmptyState displayText={displayText} headerTitle={headerTitle} />
+      )}
+    </>
+  );
+};
+
+export default Forms;

--- a/src/widgets/forms/forms.resource.ts
+++ b/src/widgets/forms/forms.resource.ts
@@ -1,0 +1,62 @@
+import { openmrsObservableFetch } from "@openmrs/esm-api";
+import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
+import { Encounter, Form } from "../types";
+
+interface searchResponse {
+  results: Array<Form>;
+}
+
+export function fetchAllForms(): Observable<Array<Form>> {
+  return openmrsObservableFetch<searchResponse>(
+    `/ws/rest/v1/form?v=custom:(uuid,name,encounterType:(uuid,name),version,published,retired,resources:(uuid,name,dataType,valueReference))`
+  ).pipe(
+    map(({ data }) => data),
+    map(({ results }) => results.map(form => toFormObject(form)))
+  );
+}
+
+export function toFormObject(openmrsRestForm): Form {
+  return {
+    uuid: openmrsRestForm.uuid,
+    name: openmrsRestForm.name || openmrsRestForm.display,
+    published: openmrsRestForm.published,
+    retired: openmrsRestForm.retired,
+    encounterTypeUuid: openmrsRestForm.encounterType
+      ? openmrsRestForm.encounterType.uuid
+      : null,
+    encounterTypeName: openmrsRestForm.encounterType
+      ? openmrsRestForm.encounterType.name
+      : null
+  };
+}
+
+export function fetchPatientEncounters(
+  patientUuid: string,
+  startDate: Date,
+  endDate: Date
+): Observable<Array<Encounter>> {
+  const customRepresentation = `custom:(uuid,encounterDatetime,encounterType:(uuid,name),form:(uuid,name,encounterType:(uuid,name),version,published,retired,resources:(uuid,name,dataType,valueReference))`;
+  return openmrsObservableFetch<searchResponse>(
+    `/ws/rest/v1/encounter?v=${customRepresentation}&patient=${patientUuid}&fromdate=${startDate.toISOString()}&todate=${endDate.toISOString()}`
+  ).pipe(
+    map(({ data }) => data),
+    map(({ results }) => results.map(result => toEncounterObject(result)))
+  );
+}
+
+export function toEncounterObject(openmrsRestEncounter: any): Encounter {
+  return {
+    uuid: openmrsRestEncounter.uuid,
+    encounterDateTime: new Date(openmrsRestEncounter.encounterDatetime),
+    encounterTypeUuid: openmrsRestEncounter.encounterType
+      ? openmrsRestEncounter.encounterType.uuid
+      : null,
+    encounterTypeName: openmrsRestEncounter.encounterType
+      ? openmrsRestEncounter.encounterType.name
+      : null,
+    form: openmrsRestEncounter.form
+      ? toFormObject(openmrsRestEncounter.form)
+      : null
+  };
+}

--- a/src/widgets/types.ts
+++ b/src/widgets/types.ts
@@ -366,3 +366,20 @@ export interface Location {
   address5?: string;
   address6?: string;
 }
+
+export type Form = {
+  uuid: string;
+  name: string;
+  published: boolean;
+  retired: boolean;
+  encounterTypeUuid?: string;
+  encounterTypeName?: string;
+};
+
+export type Encounter = {
+  uuid: string;
+  encounterDateTime: Date;
+  encounterTypeUuid?: string;
+  encounterTypeName?: string;
+  form?: Form;
+};


### PR DESCRIPTION
### What does this PR do? 

1. Add ability to launch form-entry forms
2. Implements the form-widget as shown in the designs [ticket](https://app.zeplin.io/project/5f7223cfda10f94d67cec6d0/screen/60182928c320622924b940ff)

### Screenshoots

![2021-02-16 18 15 36](https://user-images.githubusercontent.com/28008754/108082589-4f655600-7083-11eb-9570-034c7595f278.gif)

### To do
1. Write tests