### PR TITLE
MF-442: Add ability to expand alert header by on the alert

### DIFF
--- a/src/widgets/vitals/vitals-biometrics.resource.tsx
+++ b/src/widgets/vitals/vitals-biometrics.resource.tsx
@@ -50,8 +50,7 @@ export function performPatientsVitalsSearch(
     `${fhirBaseUrl}/Observation?subject:Patient=${patientID}&code=` +
       Object.values(vitalsConcepts).join(",") +
       "&_summary=data&_sort=-date" +
-      `&_count=${pageSize}` +
-      `&_elements=code,valueQuantity,issued`
+      `&_count=${pageSize}`
   ).pipe(
     map(({ data }) => {
       return data.entry;

--- a/src/widgets/vitals/vitals-biometrics.resource.tsx
+++ b/src/widgets/vitals/vitals-biometrics.resource.tsx
@@ -50,7 +50,8 @@ export function performPatientsVitalsSearch(
     `${fhirBaseUrl}/Observation?subject:Patient=${patientID}&code=` +
       Object.values(vitalsConcepts).join(",") +
       "&_summary=data&_sort=-date" +
-      `&_count=${pageSize}`
+      `&_count=${pageSize}` +
+      `&_elements=code,valueQuantity,issued`
   ).pipe(
     map(({ data }) => {
       return data.entry;

--- a/src/widgets/vitals/vitals-header/vital-header-state.component.test.tsx
+++ b/src/widgets/vitals/vitals-header/vital-header-state.component.test.tsx
@@ -39,9 +39,7 @@ describe("<VitalHeader/>", () => {
     expect(
       screen.getByText(/Last recorded: 27 - Nov - 2020/i)
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /Record Vitals/i })
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Record Vitals/)).toBeInTheDocument();
     const chevronDown = screen.getByTitle(/ChevronDown/);
 
     userEvent.click(chevronDown);

--- a/src/widgets/vitals/vitals-header/vital-header-title.component.scss
+++ b/src/widgets/vitals/vitals-header/vital-header-title.component.scss
@@ -21,6 +21,8 @@
   align-items: center;
   height: $spacing-09;
   padding: $spacing-05;
+  outline: none;
+  pointer-events: visibleFill;
 }
 
 .vitalName {
@@ -35,4 +37,8 @@
 
 .expandButton {
   color: $color-blue-60-2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
 }

--- a/src/widgets/vitals/vitals-header/vital-header-title.component.test.tsx
+++ b/src/widgets/vitals/vitals-header/vital-header-title.component.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { getByText, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import VitalsHeaderStateTitle from "./vital-header-title.component";
-import { PatientVitals } from "../vitals-card.resource";
+import { PatientVitals } from "../vitals-biometrics.resource";
 
 describe("<VitalsHeaderStateDetails/>", () => {
   const mockToggleView = jest.fn();
@@ -35,9 +35,7 @@ describe("<VitalsHeaderStateDetails/>", () => {
         showDetails={mockParamas.showDetails}
       />
     );
-    expect(
-      screen.getByRole("button", { name: /Record Vitals/i })
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Record Vitals/i)).toBeInTheDocument();
     expect(screen.getByText(/Vitals & Biometrics/i)).toBeInTheDocument();
     expect(
       screen.getByText(/Last recorded: 12 - Mar - 2019/i)

--- a/src/widgets/vitals/vitals-header/vital-header-title.component.tsx
+++ b/src/widgets/vitals/vitals-header/vital-header-title.component.tsx
@@ -39,7 +39,12 @@ const VitalsHeaderStateTitle: React.FC<VitalsHeaderStateTitleProps> = ({
   return (
     <>
       {!isEmpty(vitals) ? (
-        <div className={styles.vitalsHeader}>
+        <div
+          className={styles.vitalsHeader}
+          role="button"
+          tabIndex={0}
+          onClick={toggleView}
+        >
           <span className={styles.alignCenter}>
             {view === "Warning" && (
               <WarningFilled20
@@ -71,13 +76,19 @@ const VitalsHeaderStateTitle: React.FC<VitalsHeaderStateTitleProps> = ({
               <ChevronUp20
                 className={styles.expandButton}
                 title={"ChevronUp"}
-                onClick={toggleView}
+                onClick={e => {
+                  e.stopPropagation();
+                  toggleView();
+                }}
               />
             ) : (
               <ChevronDown20
                 className={styles.expandButton}
                 title={"ChevronDown"}
-                onClick={toggleView}
+                onClick={e => {
+                  e.stopPropagation();
+                  toggleView();
+                }}
               />
             )}
           </div>
@@ -100,7 +111,12 @@ const VitalsHeaderStateTitle: React.FC<VitalsHeaderStateTitleProps> = ({
             </span>
           </span>
           <div className={styles.alignCenter}>
-            <Button className={styles.buttonText} kind="ghost" size="small">
+            <Button
+              className={styles.buttonText}
+              onClick={launchVitalsBiometricsForm}
+              kind="ghost"
+              size="small"
+            >
               {t("recordVitals", "Record Vitals")}
             </Button>
           </div>

--- a/src/widgets/vitals/vitals-overview.component.tsx
+++ b/src/widgets/vitals/vitals-overview.component.tsx
@@ -58,10 +58,11 @@ const VitalsOverview: React.FC = () => {
   const headerTitle = t("vitals", "Vitals");
 
   React.useEffect(() => {
-    if (!isLoadingPatient && patientUuid) {
+    if (patientUuid) {
       const subscription = performPatientsVitalsSearch(
         config.concepts,
-        patientUuid
+        patientUuid,
+        100
       ).subscribe(
         vitals => {
           setVitals(vitals);
@@ -71,10 +72,9 @@ const VitalsOverview: React.FC = () => {
           createErrorHandler();
         }
       );
-
       return () => subscription.unsubscribe();
     }
-  }, [isLoadingPatient, patientUuid, config.concepts]);
+  }, [patientUuid]);
 
   const tableHeaders = [
     { key: "date", header: "Date", isSortable: true },


### PR DESCRIPTION
### ticket

[MF-442](https://issues.openmrs.org/projects/MF/issues/MF-442?filter=allissues)

### What does this PR do?

1. Add ability to expand and collapse alert header by clicking anywhere on the alert
2. remove config as a dependency as it cause un-necessary re-render

### screenshoot

![2021-02-22 17 05 35](https://user-images.githubusercontent.com/28008754/108731539-b5e3eb80-753d-11eb-8e32-00082c152fe6.gif)
