### PR TITLE
Fix patient banner overflow menu margin

### DIFF
--- a/src/ui-components/custom-overflow-menu/overflow-menu.component.tsx
+++ b/src/ui-components/custom-overflow-menu/overflow-menu.component.tsx
@@ -28,7 +28,8 @@ export default function CustomOverflowMenuComponent(props) {
       className="bx--overflow-menu"
       style={{
         width: "auto",
-        height: "auto"
+        height: "auto",
+        marginBottom: "-1.5rem"
       }}
       ref={wrapperRef}
     >


### PR DESCRIPTION
Applies a bottom margin to the overflow menu to keep it in line with the rest of the items in the patient banner. See before and after shots below for context.

<img width="1177" alt="Screenshot 2021-03-24 at 16 47 03" src="https://user-images.githubusercontent.com/8509731/112320998-9832af00-8cc0-11eb-92d2-63c0250a0c8f.png">

<img width="1177" alt="Screenshot 2021-03-24 at 16 51 43" src="https://user-images.githubusercontent.com/8509731/112321621-3f174b00-8cc1-11eb-966a-84119b683fd5.png">



