### PR TITLE
Add default value for errorCopy translation

### DIFF
--- a/src/ui-components/error-state/error-state.component.tsx
+++ b/src/ui-components/error-state/error-state.component.tsx
@@ -18,7 +18,12 @@ const EmptyState: React.FC<ErrorStateProps> = ({ error, headerTitle }) => {
         {t("error", "Error")} {`${error?.response?.status}: `}
         {error?.response?.statusText}
       </p>
-      <p className={styles.errorCopy}>{t("errorCopy")}</p>
+      <p className={styles.errorCopy}>
+        {t(
+          "errorCopy",
+          "Sorry, there was a problem displaying this information. You can try to reload this page, or contact the site administrator and quote the error code above."
+        )}
+      </p>
     </Tile>
   );
 };


### PR DESCRIPTION
Adds an optional default value for the `errorCopy` translation in the `ErrorState` component. This
is in keeping with the convention we've established in this repo where we provide the translation key as well as an optional default value. This default value will be displayed in case translations don't work - as is the situation now, for reasons I'm not sure of.

<img width="583" alt="Screenshot 2021-03-24 at 22 37 50" src="https://user-images.githubusercontent.com/8509731/112373236-c7154900-8cf1-11eb-8c34-2cbcd48eee17.png">
