### PR TITLE
MF-513: Patient banner UI enhancements

### DIFF
--- a/src/ui-components/custom-overflow-menu/overflow-menu.component.tsx
+++ b/src/ui-components/custom-overflow-menu/overflow-menu.component.tsx
@@ -29,7 +29,8 @@ export default function CustomOverflowMenuComponent(props) {
       style={{
         width: "auto",
         height: "auto",
-        marginBottom: "-1.5rem"
+        marginBottom: "-1.5rem",
+        marginTop: "-1.25rem"
       }}
       ref={wrapperRef}
     >
@@ -44,7 +45,7 @@ export default function CustomOverflowMenuComponent(props) {
         style={{
           width: "auto",
           height: "auto",
-          padding: "1em",
+          padding: "1rem",
           color: "#0f62fe",
           boxShadow: showMenu ? "0 2px 6px 0 rgb(0 0 0 / 30%)" : "none"
         }}
@@ -61,7 +62,7 @@ export default function CustomOverflowMenuComponent(props) {
         style={{
           minWidth: "15rem",
           display: showMenu ? "block" : "none",
-          top: "3.75em"
+          top: "3.75rem"
         }}
       >
         <ul className="bx--overflow-menu-options__content">{children}</ul>

--- a/src/widgets/banner/patient-banner.component.tsx
+++ b/src/widgets/banner/patient-banner.component.tsx
@@ -2,9 +2,10 @@ import React, { useEffect, useState } from "react";
 import dayjs from "dayjs";
 import Button from "carbon-components-react/es/components/Button";
 import Tag from "carbon-components-react/es/components/Tag";
-import TooltipDefination from "carbon-components-react/es/components/TooltipDefinition";
-import CaretDown16 from "@carbon/icons-react/es/caret--down/16";
-import CaretUp16 from "@carbon/icons-react/es/caret--up/16";
+import TooltipDefinition from "carbon-components-react/es/components/TooltipDefinition";
+import ChevronDown16 from "@carbon/icons-react/es/chevron--down/16";
+import ChevronUp16 from "@carbon/icons-react/es/chevron--up/16";
+import OverflowMenuVertical16 from "@carbon/icons-react/es/overflow-menu--vertical/16";
 import capitalize from "lodash-es/capitalize";
 import ContactDetails from "../contact-details/contact-details.component";
 import styles from "./patient-banner.scss";
@@ -14,17 +15,11 @@ import { age } from "../contact-details/age-helpers";
 import { useVisit } from "../visit/use-visit";
 import { getStartedVisit, visitItem } from "../visit/visit-utils";
 import CustomOverflowMenuComponent from "../../ui-components/custom-overflow-menu/overflow-menu.component";
-import { OverflowMenuVertical24 } from "@carbon/icons-react";
 
 export default function PatientBanner() {
   const { currentVisit, error } = useVisit();
   const [showContactDetails, setShowContactDetails] = useState(false);
-  const [
-    isLoadingPatient,
-    patient,
-    patientUuid,
-    patientErr
-  ] = useCurrentPatient();
+  const [isLoadingPatient, patient, , patientErr] = useCurrentPatient();
   const [hasActiveVisit, setActiveVisit] = useState(false);
   const { t } = useTranslation();
   const toggleContactDetails = () => {
@@ -68,11 +63,12 @@ export default function PatientBanner() {
                     {getPatientNames()}
                   </span>
                   {hasActiveVisit && (
-                    <TooltipDefination
+                    <TooltipDefinition
+                      style={{ top: "-0.25rem" }}
                       align="end"
                       tooltipText={
                         <div className={styles.tooltipPadding}>
-                          <h6 style={{ marginBottom: "0.5em" }}>
+                          <h6 style={{ marginBottom: "0.5rem" }}>
                             {currentVisit &&
                               currentVisit.visitType &&
                               currentVisit.visitType.name}
@@ -90,15 +86,18 @@ export default function PatientBanner() {
                         </div>
                       }
                     >
-                      <Tag type="blue">{t("Active Visit", "Active Visit")}</Tag>
-                    </TooltipDefination>
+                      <Tag type="blue">{t("activeVisit", "Active Visit")}</Tag>
+                    </TooltipDefinition>
                   )}
                 </div>
                 <div>
                   <CustomOverflowMenuComponent
                     menuTitle={
                       <>
-                        Actions <OverflowMenuVertical24 />
+                        Actions{" "}
+                        <OverflowMenuVertical16
+                          style={{ marginLeft: "0.5rem" }}
+                        />
                       </>
                     }
                   >
@@ -124,13 +123,14 @@ export default function PatientBanner() {
                 </span>
                 <Button
                   kind="ghost"
-                  renderIcon={showContactDetails ? CaretUp16 : CaretDown16}
+                  renderIcon={showContactDetails ? ChevronUp16 : ChevronDown16}
                   iconDescription="Toggle contact details"
                   onClick={toggleContactDetails}
+                  style={{ marginTop: "-0.25rem" }}
                 >
                   {showContactDetails
-                    ? "Hide Contact Details"
-                    : "Show Contact Details"}
+                    ? t("hideAllDetails", "Hide all details")
+                    : t("showAllDetails", "Show all details")}
                 </Button>
               </div>
             </div>

--- a/src/widgets/banner/patient-banner.scss
+++ b/src/widgets/banner/patient-banner.scss
@@ -15,8 +15,8 @@
 }
 
 .patientAvatar {
-  width: 5rem;
-  height: 5rem;
+  width: 80px;
+  height: 80px;
   margin: 1rem;
   border-radius: 1px;
 }
@@ -28,7 +28,7 @@
 .demographics {
   @include carbon--type-style("body-short-02");
   color: $text-02;
-  margin-top: 0.5rem;
+  margin-top: 0.375rem;
 }
 
 .row {
@@ -36,7 +36,6 @@
   flex-direction: row;
   justify-content: space-between;
   align-items: baseline;
-  margin-top: -0.125rem;
 }
 
 .nameRow {
@@ -44,7 +43,7 @@
   flex-flow: row wrap;
   justify-content: space-between;
   align-items: center;
-  margin-top: 0.625rem;
+  margin-top: 0.875rem;
 }
 
 .identifiers {
@@ -53,7 +52,7 @@
 }
 
 .tooltipPadding {
-  padding: 0.25em;
+  padding: 0.25rem;
 }
 
 .tooltipSmalltext {

--- a/src/widgets/banner/patient-banner.test.tsx
+++ b/src/widgets/banner/patient-banner.test.tsx
@@ -29,22 +29,22 @@ describe("<PatientBanner />", () => {
   it("clicking the button toggles displaying the patient's contact details", () => {
     renderPatientBanner();
 
-    const showContactDetailsBtn = screen.getByRole("button", {
-      name: "Show Contact Details"
+    const showAllDetailsBtn = screen.getByRole("button", {
+      name: "Show all details"
     });
 
-    fireEvent.click(showContactDetailsBtn);
+    fireEvent.click(showAllDetailsBtn);
 
-    const hideContactDetailsBtn = screen.getByRole("button", {
-      name: "Hide Contact Details"
+    const hideAllDetailsBtn = screen.getByRole("button", {
+      name: "Hide all details"
     });
-    expect(hideContactDetailsBtn).toBeInTheDocument();
+    expect(hideAllDetailsBtn).toBeInTheDocument();
     expect(screen.getByText("Address")).toBeInTheDocument();
     expect(screen.getByText("Contact Details")).toBeInTheDocument();
 
-    fireEvent.click(hideContactDetailsBtn);
+    fireEvent.click(hideAllDetailsBtn);
 
-    expect(showContactDetailsBtn).toBeInTheDocument();
+    expect(showAllDetailsBtn).toBeInTheDocument();
   });
 
   it("should display the Active Visit tag when there is an active visit", () => {

--- a/src/widgets/vitals/vitals-header/vital-header-title.component.tsx
+++ b/src/widgets/vitals/vitals-header/vital-header-title.component.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import styles from "./vital-header-title.component.scss";
 import WarningFilled20 from "@carbon/icons-react/es/warning--filled/20";
-import ChevronDown20 from "@carbon/icons-react/es/chevron--down/20";
-import ChevronUp20 from "@carbon/icons-react/es/chevron--up/20";
+import ChevronDown16 from "@carbon/icons-react/es/chevron--down/16";
+import ChevronUp16 from "@carbon/icons-react/es/chevron--up/16";
 import dayjs from "dayjs";
 import Button from "carbon-components-react/es/components/Button";
 import isEmpty from "lodash-es/isEmpty";
@@ -68,7 +68,7 @@ const VitalsHeaderStateTitle: React.FC<VitalsHeaderStateTitleProps> = ({
               {t("recordVitals", "Record Vitals")}
             </Button>
             {showDetails ? (
-              <ChevronUp20
+              <ChevronUp16
                 className={styles.expandButton}
                 title={"ChevronUp"}
                 onClick={e => {
@@ -77,7 +77,7 @@ const VitalsHeaderStateTitle: React.FC<VitalsHeaderStateTitleProps> = ({
                 }}
               />
             ) : (
-              <ChevronDown20
+              <ChevronDown16
                 className={styles.expandButton}
                 title={"ChevronDown"}
                 onClick={e => {


### PR DESCRIPTION
[Ticket](https://issues.openmrs.org/browse/MF-513)

A slew of enhancements to the patient banner UI including:

- Adding an SVG as the patient avatar placeholder image (replaces the existing png).
- Adding explicit sizing (`5 rem` height and width) to the placeholder SVG. This resolves an issue where the sizing of the image was being determined implicitly by the browser which led to it being rendered as a 72px x 72px image. This step ensures that the image takes up the expected amount of space in all the places where it is being used - the patient registration form, the patient search UI, and the patient banner.
- Changing the alignment of various items in the patient banner. This is a consequence of the patient's avatar now being of the expected size. We can now tailor the size and alignment of surrounding items to better match what is outlined in the designs.
- Changing the size of various icons from 20px to 16px per the designs.
- Changing the text of the `Show/Hide Contact Details` button to `Show/Hide all details` per the designs. Changing the text case to sentence case was a suggestion by Ciaran (he intends to change the designs to reflect that Carbon convention).

Related: https://github.com/openmrs/openmrs-esm-patient-registration/pull/86


After shots (bottom one has the `Active Visit` tag showing):

<img width="903" alt="Screenshot 2021-03-25 at 23 44 48" src="https://user-images.githubusercontent.com/8509731/112541188-26dc2480-8dc4-11eb-9402-7acf721ba4d2.png">

<img width="902" alt="Screenshot 2021-03-25 at 23 43 29" src="https://user-images.githubusercontent.com/8509731/112541206-2c396f00-8dc4-11eb-95ac-b711c219f619.png">
