### PR TITLE
MF-534: Fix vitals signs display values when units are absent

### DIFF
--- a/__mocks__/carbon-interface.ts
+++ b/__mocks__/carbon-interface.ts
@@ -1,6 +1,8 @@
-export declare enum ScaleTypes {
+enum ScaleTypes {
   TIME = "time",
   LINEAR = "linear",
   LOG = "log",
   LABELS = "labels"
 }
+
+export { ScaleTypes };

--- a/src/widgets/vitals/vitals-biometrics-form/use-vitalsigns.ts
+++ b/src/widgets/vitals/vitals-biometrics-form/use-vitalsigns.ts
@@ -13,6 +13,7 @@ export interface ConceptMetaData {
   lowCritical: number | string | null;
   units: string | null;
 }
+
 export const useVitalsSignsConceptMetaData = () => {
   const [
     vitalsSignsConceptMetadata,
@@ -32,8 +33,14 @@ export const useVitalsSignsConceptMetaData = () => {
     }
     return () => ac && ac.abort();
   }, []);
+
   const conceptsUnits = vitalsSignsConceptMetadata.map(
     conceptUnit => conceptUnit.units
   );
+
   return { vitalsSignsConceptMetadata, conceptsUnits };
+};
+
+export const withUnit = (label: string, unit: string | null | undefined) => {
+  return `${label} ${unit ? `(${unit})` : ""}`;
 };

--- a/src/widgets/vitals/vitals-chart.component.tsx
+++ b/src/widgets/vitals/vitals-chart.component.tsx
@@ -88,27 +88,27 @@ const VitalsChart: React.FC<VitalsChartProps> = ({
   const vitalSigns = [
     {
       id: "bloodPressure",
-      title: `BP (${bloodPressureUnit})`,
+      title: `BP ${bloodPressureUnit ? `(${bloodPressureUnit})` : ""}`,
       value: "systolic"
     },
     {
       id: "oxygenSaturation",
-      title: `SPO2 (${oxygenSaturationUnit})`,
+      title: `SPO2 ${oxygenSaturationUnit ? `(${oxygenSaturationUnit})` : ""}`,
       value: "oxygenSaturation"
     },
     {
       id: "temperature",
-      title: `Temp (${temperatureUnit})`,
+      title: `Temp ${temperatureUnit ? `(${temperatureUnit})` : ""}`,
       value: "temperature"
     },
     {
       id: "Respiratory Rate",
-      title: `R.Rate ${respiratoryRateUnit}`,
+      title: `R. Rate ${respiratoryRateUnit ? `(${respiratoryRateUnit})` : ""}`,
       value: "respiratoryRate"
     },
     {
       id: "pulse",
-      title: `Pulse (${pulseUnit})`,
+      title: `Pulse ${pulseUnit ? `(${pulseUnit})` : ""}`,
       value: "pulse"
     }
   ];

--- a/src/widgets/vitals/vitals-chart.component.tsx
+++ b/src/widgets/vitals/vitals-chart.component.tsx
@@ -3,6 +3,7 @@ import dayjs from "dayjs";
 import styles from "./vitals-chart.component.scss";
 import RadioButton from "carbon-components-react/es/components/RadioButton";
 import RadioButtonGroup from "carbon-components-react/es/components/RadioButtonGroup";
+import { withUnit } from "./vitals-biometrics-form/use-vitalsigns";
 import { PatientVitals } from "./vitals-biometrics.resource";
 import { LineChart } from "@carbon/charts-react";
 import { LineChartOptions } from "@carbon/charts/interfaces/charts";
@@ -88,27 +89,27 @@ const VitalsChart: React.FC<VitalsChartProps> = ({
   const vitalSigns = [
     {
       id: "bloodPressure",
-      title: `BP ${bloodPressureUnit ? `(${bloodPressureUnit})` : ""}`,
+      title: withUnit("BP", bloodPressureUnit),
       value: "systolic"
     },
     {
       id: "oxygenSaturation",
-      title: `SPO2 ${oxygenSaturationUnit ? `(${oxygenSaturationUnit})` : ""}`,
+      title: withUnit("SPO2", oxygenSaturationUnit),
       value: "oxygenSaturation"
     },
     {
       id: "temperature",
-      title: `Temp ${temperatureUnit ? `(${temperatureUnit})` : ""}`,
+      title: withUnit("Temp", temperatureUnit),
       value: "temperature"
     },
     {
       id: "Respiratory Rate",
-      title: `R. Rate ${respiratoryRateUnit ? `(${respiratoryRateUnit})` : ""}`,
+      title: withUnit("R. Rate", respiratoryRateUnit),
       value: "respiratoryRate"
     },
     {
       id: "pulse",
-      title: `Pulse ${pulseUnit ? `(${pulseUnit})` : ""}`,
+      title: withUnit("Pulse", pulseUnit),
       value: "pulse"
     }
   ];

--- a/src/widgets/vitals/vitals-overview.component.tsx
+++ b/src/widgets/vitals/vitals-overview.component.tsx
@@ -26,7 +26,10 @@ import {
   createErrorHandler,
   switchTo
 } from "@openmrs/esm-framework";
-import { useVitalsSignsConceptMetaData } from "./vitals-biometrics-form/use-vitalsigns";
+import {
+  useVitalsSignsConceptMetaData,
+  withUnit
+} from "./vitals-biometrics-form/use-vitalsigns";
 import {
   performPatientsVitalsSearch,
   PatientVitals
@@ -47,7 +50,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = () => {
     ,
     ,
     pulseUnit,
-    oxygenationSaturationUnit,
+    oxygenSaturationUnit,
     ,
     respiratoryRateUnit
   ] = conceptsUnits;
@@ -88,22 +91,20 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = () => {
     { key: "date", header: "Date", isSortable: true },
     {
       key: "bloodPressure",
-      header: `BP ${bloodPressureUnit ? `(${bloodPressureUnit})` : ""}`
+      header: withUnit("BP", bloodPressureUnit)
     },
     {
       key: "respiratoryRate",
-      header: `R. Rate ${respiratoryRateUnit ? `(${respiratoryRateUnit})` : ""}`
+      header: withUnit("R. Rate", respiratoryRateUnit)
     },
-    { key: "pulse", header: `Pulse ${pulseUnit ? `(${pulseUnit})` : ""}` },
+    { key: "pulse", header: withUnit("Pulse", pulseUnit) },
     {
       key: "spo2",
-      header: `SPO2 ${
-        oxygenationSaturationUnit ? `(${oxygenationSaturationUnit})` : ""
-      }`
+      header: withUnit("SPO2", oxygenSaturationUnit)
     },
     {
       key: "temperature",
-      header: `Temp ${temperatureUnit ? `(${temperatureUnit})` : ""}`
+      header: withUnit("Temp", temperatureUnit)
     }
   ];
 

--- a/src/widgets/vitals/vitals-overview.component.tsx
+++ b/src/widgets/vitals/vitals-overview.component.tsx
@@ -47,7 +47,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = () => {
     ,
     ,
     pulseUnit,
-    oxygenationUnit,
+    oxygenationSaturationUnit,
     ,
     respiratoryRateUnit
   ] = conceptsUnits;
@@ -86,13 +86,24 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = () => {
 
   const tableHeaders = [
     { key: "date", header: "Date", isSortable: true },
-    { key: "bloodPressure", header: `BP (${bloodPressureUnit})` },
-    { key: "rrate", header: `Rate (${respiratoryRateUnit})` },
-    { key: "pulse", header: `Pulse (${pulseUnit})` },
-    { key: "spo2", header: `SPO2 (${oxygenationUnit})` },
+    {
+      key: "bloodPressure",
+      header: `BP ${bloodPressureUnit ? `(${bloodPressureUnit})` : ""}`
+    },
+    {
+      key: "respiratoryRate",
+      header: `R. Rate ${respiratoryRateUnit ? `(${respiratoryRateUnit})` : ""}`
+    },
+    { key: "pulse", header: `Pulse ${pulseUnit ? `(${pulseUnit})` : ""}` },
+    {
+      key: "spo2",
+      header: `SPO2 ${
+        oxygenationSaturationUnit ? `(${oxygenationSaturationUnit})` : ""
+      }`
+    },
     {
       key: "temperature",
-      header: `Temp (${temperatureUnit})`
+      header: `Temp ${temperatureUnit ? `(${temperatureUnit})` : ""}`
     }
   ];
 
@@ -106,7 +117,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = () => {
         pulse: vital.pulse,
         spo2: vital.oxygenSaturation,
         temperature: vital.temperature,
-        rrate: vital.respiratoryRate
+        respiratoryRate: vital.respiratoryRate
       };
     });
 

--- a/src/widgets/vitals/vitals-overview.test.tsx
+++ b/src/widgets/vitals/vitals-overview.test.tsx
@@ -14,6 +14,7 @@ jest.mock("./vitals-biometrics.resource", () => ({
 }));
 
 jest.mock("./vitals-biometrics-form/use-vitalsigns", () => ({
+  ...jest.requireActual("./vitals-biometrics-form/use-vitalsigns"),
   useVitalsSignsConceptMetaData: jest.fn().mockReturnValue({
     conceptsUnits: [
       "mmHg",

--- a/src/widgets/vitals/vitals-overview.test.tsx
+++ b/src/widgets/vitals/vitals-overview.test.tsx
@@ -1,59 +1,106 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { BrowserRouter } from "react-router-dom";
-import VitalsOverview from "./vitals-overview.component";
 import { of } from "rxjs/internal/observable/of";
-
 import { mockVitalData } from "../../../__mocks__/vitals.mock";
-import { openWorkspaceTab } from "../shared-utils";
 import { performPatientsVitalsSearch } from "./vitals-biometrics.resource";
+import VitalsOverview from "./vitals-overview.component";
 
-const mockOpenWorkspaceTab = openWorkspaceTab as jest.Mock;
 const mockPerformPatientVitalsSearch = performPatientsVitalsSearch as jest.Mock;
-const mockVitalsConfig = {
-  vitals: {
-    bloodPressureUnit: "mmHg",
-    oxygenSaturationUnit: "%",
-    pulseUnit: "bpm",
-    temperatureUnit: "°C"
-  }
-};
-
-const renderVitalsOverview = () =>
-  render(
-    <BrowserRouter>
-      <VitalsOverview config={mockVitalsConfig} />
-    </BrowserRouter>
-  );
 
 jest.mock("./vitals-biometrics.resource", () => ({
   performPatientsVitalsSearch: jest.fn()
 }));
 
-jest.mock("../shared-utils", () => ({
-  openWorkspaceTab: jest.fn()
+jest.mock("./vitals-biometrics-form/use-vitalsigns", () => ({
+  useVitalsSignsConceptMetaData: jest.fn().mockReturnValue({
+    conceptsUnits: [
+      "mmHg",
+      "mmHg",
+      "°C",
+      "cm",
+      "kg",
+      "beats/min",
+      "%",
+      "cm",
+      null
+    ]
+  })
 }));
-// TO DO Write test for carbon intergration
+
+const renderVitalsOverview = () =>
+  render(
+    <BrowserRouter>
+      <VitalsOverview />
+    </BrowserRouter>
+  );
+
 describe("<VitalsOverview />", () => {
-  beforeEach(() => {
-    mockOpenWorkspaceTab.mockReset;
-    mockPerformPatientVitalsSearch.mockReset;
+  it("renders an overview of the patient's vitals", async () => {
+    mockPerformPatientVitalsSearch.mockReturnValue(of(mockVitalData));
+    await renderVitalsOverview();
+
+    screen.findByRole("heading", { name: "Vitals" });
+    expect(
+      screen.getByRole("button", { name: /table view/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /chart view/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: /date/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: /bp \(mmhg\)/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: /rate/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: /pulse \(beats\/min\)/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: /spo2 \(%\)/i })
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("row").length).toEqual(6);
   });
 
-  it("should display an overview of the patient's vitals data", async () => {
+  it("can toggle between table view and chart view", async () => {
     mockPerformPatientVitalsSearch.mockReturnValue(of(mockVitalData));
+    await renderVitalsOverview();
 
-    renderVitalsOverview();
+    const chartViewButton = screen.getByRole("button", {
+      name: /chart view/i
+    });
+    userEvent.click(chartViewButton);
 
-    await screen.findByRole("heading", { name: "Vitals" });
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.getByText(/Vital Sign Displayed/)).toBeInTheDocument();
+    expect(screen.getAllByRole("radio").length).toEqual(5);
+    expect(screen.getByRole("radio", { name: /bp \(mmHg\)/i })).toBeChecked();
+
+    const tableViewButton = screen.getByRole("button", {
+      name: /table view/i
+    });
+    userEvent.click(tableViewButton);
+
+    expect(screen.queryByText(/Vital Sign Displayed/)).not.toBeInTheDocument();
+    expect(screen.getByRole("table")).toBeInTheDocument();
   });
 
   it("renders an empty state view when vitals data is absent", async () => {
     mockPerformPatientVitalsSearch.mockReturnValue(of([]));
+    await renderVitalsOverview();
 
-    renderVitalsOverview();
-
-    await screen.findByRole("heading", { name: "Vitals" });
-    expect(screen.getByText("Vitals")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Vitals" })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("columnheader")).not.toBeInTheDocument();
+    expect(screen.queryByRole("row")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/There are no vital signs to display for this patient/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Record vital signs/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
[Ticket](https://issues.openmrs.org/browse/MF-524)

- Change the display logic of the vital signs table headers so that units are shown only when present.
- Change the display logic of the vital signs radio buttons in the chart view so that units are shown only when present.
- Change the `Rate` label to `R. Rate` per the designs.
- Add tests 🚀

Fixes:
<img width="1063" alt="Screenshot 2021-03-30 at 10 31 41" src="https://user-images.githubusercontent.com/8509731/112982966-c5baa500-9165-11eb-8b59-e98ac3526a51.png">
<img width="415" alt="Screenshot 2021-03-30 at 14 05 22" src="https://user-images.githubusercontent.com/8509731/112982988-cbb08600-9165-11eb-832a-e329ea72e742.png">

To:
<img width="1056" alt="Screenshot 2021-03-30 at 14 08 58" src="https://user-images.githubusercontent.com/8509731/112983042-dc60fc00-9165-11eb-854c-e29d1b57a285.png">
<img width="289" alt="Screenshot 2021-03-30 at 14 09 07" src="https://user-images.githubusercontent.com/8509731/112983062-e125b000-9165-11eb-9f45-130c653acfd1.png">
