### PR TITLE
Rename pulse vital sign labels to read as heart rate-MF-525

### DIFF
--- a/src/widgets/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/src/widgets/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -157,7 +157,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({
           </Column>
           <Column>
             <VitalsBiometricInput
-              title={t("pulse", "Pulse")}
+              title={t("heartRate", "Heart Rate")}
               onInputChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                 setPatientVitalAndBiometrics({
                   ...patientVitalAndBiometrics,

--- a/src/widgets/vitals/vitals-chart.component.tsx
+++ b/src/widgets/vitals/vitals-chart.component.tsx
@@ -109,7 +109,7 @@ const VitalsChart: React.FC<VitalsChartProps> = ({
     },
     {
       id: "pulse",
-      title: withUnit("Pulse", pulseUnit),
+      title: withUnit("H. Rate", pulseUnit),
       value: "pulse"
     }
   ];

--- a/src/widgets/vitals/vitals-overview.component.tsx
+++ b/src/widgets/vitals/vitals-overview.component.tsx
@@ -97,7 +97,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = () => {
       key: "respiratoryRate",
       header: withUnit("R. Rate", respiratoryRateUnit)
     },
-    { key: "pulse", header: withUnit("Pulse", pulseUnit) },
+    { key: "pulse", header: withUnit("H. Rate", pulseUnit) },
     {
       key: "spo2",
       header: withUnit("SPO2", oxygenSaturationUnit)

--- a/src/widgets/vitals/vitals-overview.test.tsx
+++ b/src/widgets/vitals/vitals-overview.test.tsx
@@ -56,10 +56,10 @@ describe("<VitalsOverview />", () => {
       screen.getByRole("columnheader", { name: /bp \(mmhg\)/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("columnheader", { name: /rate/i })
+      screen.getByRole("columnheader", { name: /R. Rate/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("columnheader", { name: /pulse \(beats\/min\)/i })
+      screen.getByRole("columnheader", { name: /H. Rate \(beats\/min\)/i })
     ).toBeInTheDocument();
     expect(
       screen.getByRole("columnheader", { name: /spo2 \(%\)/i })


### PR DESCRIPTION
This is to solve the issue [MF-525](https://issues.openmrs.org/browse/MF-525).
As per the [designs](https://zpl.io/2GDP91E), the Pulse vital sign is being represented as Heart Rate. We need to propagate this change across the places where the old label is being used - it should read as the abbreviated form - H. Rate in the vitals overview component (both table and chart) and as Heart Rate in the vitals form.
The changes have been made and the local dev shows the results as:
<h3>In vitals widget</h3>

![image](https://user-images.githubusercontent.com/61249902/113061939-837a7d80-91d0-11eb-851a-1f53ceb8df1b.png)

<h3>In vitals form</h3>

![image](https://user-images.githubusercontent.com/61249902/113062059-c3416500-91d0-11eb-8039-f149d8542cad.png)

Thank you.